### PR TITLE
Prevent error popup after deleteting a record

### DIFF
--- a/timetagger/client/stores.py
+++ b/timetagger/client/stores.py
@@ -411,8 +411,10 @@ class RecordStore(BaseStore):
                 nr1 = cur_record.t1 // _min_heap_bin_size
                 nr2 = cur_record.t2 // _min_heap_bin_size
                 for nr in range(nr1, nr2 + 1):
-                    changed_bins[nr] = True
-                    bin2record_keys[nr].pop(key)
+                    if bin2record_keys.get(nr, None) is not None:
+                        # bin2record_keys[nr].pop(key, None)
+                        bin2record_keys[nr].pop(key, None)
+                        changed_bins[nr] = True
                 self._running_records.pop(key, None)
 
             # Add new_record to bins in layer 0
@@ -899,6 +901,7 @@ class ConnectedDataStore(BaseDataStore):
                 except Exception as err:
                     self._set_state("warning")
                     window.alert(str(err))
+                    console.exception(err)
 
                 # Set state to ok if we got new items, and if there were no errors
                 if ob.settings or ob.records:

--- a/timetagger/client/stores.py
+++ b/timetagger/client/stores.py
@@ -412,7 +412,6 @@ class RecordStore(BaseStore):
                 nr2 = cur_record.t2 // _min_heap_bin_size
                 for nr in range(nr1, nr2 + 1):
                     if bin2record_keys.get(nr, None) is not None:
-                        # bin2record_keys[nr].pop(key, None)
                         bin2record_keys[nr].pop(key, None)
                         changed_bins[nr] = True
                 self._running_records.pop(key, None)
@@ -895,13 +894,14 @@ class ConnectedDataStore(BaseDataStore):
                     self.settings._put_received(*ob.settings)
                 except Exception as err:
                     self._set_state("warning")
-                    window.alert(str(err))
+                    console.error(err)
+                    window.alert("Sync error (settings), see dev console for details.")
                 try:
                     self.records._put_received(*ob.records)
                 except Exception as err:
                     self._set_state("warning")
-                    window.alert(str(err))
-                    console.exception(err)
+                    console.error(err)
+                    window.alert("Sync error (records), see dev console for details.")
 
                 # Set state to ok if we got new items, and if there were no errors
                 if ob.settings or ob.records:


### PR DESCRIPTION
Closes #48

The issue was that when a record is `put` in the store, its previous version is first removed. However, a deleted record (which is not actually deleted, but hidden) is not present in the heap, so removing it fails. I added tests that failed because of this, and then fixed it by guarding against this case.

In case you've experienced this error, there should not be any implications. The error occurs when the server "confirms" the update of the record.