### PR TITLE
Refactor how tags are suggested

### DIFF
--- a/timetagger/app/app.scss
+++ b/timetagger/app/app.scss
@@ -29,8 +29,8 @@ body.darkmode #canvas { background: #171E28; }
     margin: 0;
     padding: 0.5em;
 }
-.dialog.verticalmenu .divider {   
-    border-top: 1px solid #bbb;    
+.dialog.verticalmenu .divider {
+    border-top: 1px solid #bbb;
     text-align: center;
     padding: 0;
     font-size: 80%;
@@ -258,6 +258,42 @@ body.darkmode .dialog button.actionbutton.submit { background: $acc_clr; }
 @media screen and (min-width: 600px) {
     .dialog button.actionbutton { margin-left: 1em; font-size: 100%; }
     .dialog button.actionbutton.submit { min-width: 7em; }
+}
+
+.dialog .tag-suggestions-autocomp {
+    position: absolute;
+    border: 1px solid #bbb;
+    border-radius: 4px;
+    background: #fff;
+    color: $prim1_clr;
+    border-top: none;
+    z-index: 99;
+    top: 100%;
+    left: 3px;
+    width: 50%;
+    max-height: 150px;
+    overflow-y: scroll;
+    box-shadow: 0 2px 2px rgba(0, 0, 0, 0.4);
+}
+
+.dialog .tag-suggestions-autocomp > div {
+    font-size: 85%;
+    padding: 4px;
+    cursor: pointer;
+    background-color: #fff;
+    border-bottom: 1px solid #d4d4d4;
+}
+.dialog .tag-suggestions-autocomp > div.meta {
+    cursor: default;
+    font-size: 70%;
+}
+.dialog .tag-suggestions-autocomp > div > span.meta {
+    font-size: 70%;
+    color: #bbb;
+    margin-left: 1em;
+}
+.dialog .tag-suggestions-autocomp .tag-suggestion.active, .dialog .tag-suggestions-autocomp > .tag-suggestion:hover {
+    background-color: #f5f5ff;
 }
 
 /* --- dialog table --- */

--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -1163,7 +1163,7 @@ class RecordDialog(BaseDialog):
         # Get what to suggest
         if tag_to_be == "#":
             headline = "Recent tags:"
-            metaprefix = "recently used "
+            metaprefix = "last used "
             suggestion_list = self._suggested_tags2
         else:
             headline = "Matching tags:"
@@ -1171,6 +1171,7 @@ class RecordDialog(BaseDialog):
             suggestion_list = self._suggested_tags3
 
         # Create suggestions
+        now = dt.now()
         self._suggested_tags4 = []
         item = document.createElement("div")
         item.classList.add("meta")
@@ -1179,7 +1180,9 @@ class RecordDialog(BaseDialog):
         for tag, tag_t2 in suggestion_list:
             if tag.startsWith(tag_to_be):
                 self._suggested_tags4.push(tag)
-                date = dt.time2localstr(tag_t2).split(" ")[0]
+                date = max(0, int((now - tag_t2) / 86400))
+                date = {0: "today", 1: "yesterday"}.get(date, date + " days ago")
+                # date = dt.time2localstr(tag_t2).split(" ")[0]
                 html = "<b>" + tag_to_be + "</b>" + tag[tag_to_be.length :]
                 html += "<span class='meta'>" + metaprefix + date + "<span>"
                 item = document.createElement("div")


### PR DESCRIPTION
Closes #53

Instead of providing a series of recently used tags, an autocomplete popup is used that:
* when only `#` is typed, shows recently used tags, ordered by relevance.
* when more chars are typed, shows matches based on all known tags.

The advantage is that the suggested tags is not cut-off arbitrarily. Well, it still only shows tags from the past 12 weeks. But the autocompletion will suggest based on all tags ever used. One downside is that you have to type `#` to invoke the suggestion. This may be resolved later.