### PR TITLE
Navigation tweeks

### DIFF
--- a/timetagger/app/app.scss
+++ b/timetagger/app/app.scss
@@ -48,17 +48,18 @@ body.darkmode .dialog.verticalmenu {
     text-decoration: none;
     background: rgba(127, 127, 127, 0.1);
 }
-.verticalmenu .grid5 {
+.verticalmenu .grid2c, .verticalmenu .grid5 {
     display: grid;
-    grid-template-columns: auto auto auto auto auto;
     grid-gap: 0;
     margin: 0;
     justify-items: stretch;
     align-items: stretch;
 }
-.verticalmenu .grid5 > * {
+.verticalmenu .grid2c > *, .verticalmenu .grid5 > *{
     text-align: center;
 }
+.verticalmenu .grid2c { grid-template-columns: 1fr auto auto 1fr; }
+.verticalmenu .grid5 { grid-template-columns: auto auto auto auto auto; }
 .dialog.verticalmenu .menu {
     display: flex;
     justify-content: space-between;
@@ -69,6 +70,14 @@ body.darkmode .dialog.verticalmenu {
     display: inline-block;
     flex: 1 1 auto;
     text-align: center;
+}
+
+span.keyhint {
+    border: 1px solid #ccc;
+    padding: 2px 4px;
+    border-radius: 3px;
+    font-size: 90%;
+    color: #ccc;
 }
 
 /**************** Tooltip ****************/

--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -490,10 +490,17 @@ class TimeSelectionDialog(BaseDialog):
 
         # Generate preamble
         html = f"""
+            <div class='grid2c'>
+                <div></div>
+                <a><i class='fas'>\uf010</i> Zoom out <span class='keyhint'>←</span></a>
+                <a><i class='fas'>\uf00e</i> Zoom in <span class='keyhint'>→</span></a>
+                <div></div>
+            </div>
+            <div style='min-height: 6px;'></div>
             <div class='grid5'>
-                <a>today [d]</a>
-                <a>this week [w]</a>
-                <a>this month [m]</a>
+                <a>today <span class='keyhint'>d</span></a>
+                <a>this week <span class='keyhint'>w</span></a>
+                <a>this month <span class='keyhint'>m</span></a>
                 <a>this quarter</a>
                 <a>this year</a>
                 <a>yesterday</a>
@@ -502,7 +509,7 @@ class TimeSelectionDialog(BaseDialog):
                 <a>last quarter</a>
                 <a>last year</a>
             </div>
-            <div style='min-height: 8px;'></div>
+            <div style='min-height: 10px;'></div>
             <div class='menu'>
                 <div style='flex: 0.5 0.5 auto; text-align: right;'>From:&nbsp;&nbsp;</div>
                 <input type="date" step="1" />
@@ -514,11 +521,19 @@ class TimeSelectionDialog(BaseDialog):
         """
 
         self.maindiv.innerHTML = html
-        presets = self.maindiv.children[0]
-        form = self.maindiv.children[2]
+        quicknav = self.maindiv.children[0]
+        presets = self.maindiv.children[2]
+        form = self.maindiv.children[4]
 
         self._t1_input = form.children[1]
         self._t2_input = form.children[3]
+
+        quicknav.children[1].onclick = lambda e: self._apply_quicknav(
+            e.target.innerText
+        )
+        quicknav.children[2].onclick = lambda e: self._apply_quicknav(
+            e.target.innerText
+        )
 
         for i in range(presets.children.length):
             but = presets.children[i]
@@ -531,6 +546,15 @@ class TimeSelectionDialog(BaseDialog):
 
         self.maindiv.classList.add("verticalmenu")
         super().open(None)
+
+    def _apply_quicknav(self, text):
+        scalestep = +1 if "out" in text.lower() else -1
+        t1, t2 = self._canvas.range.get_snap_range(scalestep)
+
+        self._t1_input.value = dt.time2localstr(t1).split(" ")[0]
+        self._t2_input.value = dt.time2localstr(t2).split(" ")[0]
+
+        self._canvas.range.animate_range(t1, t2)
 
     def _apply_preset(self, text):
         text = text.lower()

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -314,8 +314,13 @@ SCALES = [
     ("6h", "5m", 8.5 * 3600, ""),  # Kind of the default view
     ("12h", "1h", 15 * 3600, ""),
     ("1D", "1h", 3 * 86400, "Day"),
-    ("1W", "1D", 2 * 7 * 86400, "Week"),  # step with 1D, 1W steps is awkward
-    ("1M", "4D", 5.3 * 7 * 86400, "Month"),  # 1M steps bit awkward, but what else?
+    ("1W", "1D", 2 * 7 * 86400, "Week"),
+    (
+        "1M",
+        "4D",
+        5.3 * 7 * 86400,
+        "Month",
+    ),  # day-steps is too many, week steps awkward ...
     ("7W", "1W", 10 * 7 * 86400, "7x7"),
     ("3M", "1M", 200 * 86400, "Quarter"),
     ("1Y", "1M", 550 * 86400, "Year"),  # step per quarter of month?
@@ -340,8 +345,8 @@ INTERVALS = [
     ("12h", "1h", "hh", 43200),
     ("1D", "3h", "DD", 86400),
     ("2D", "6h", "DD", 172_800),
-    ("5D", "1D", "DM", 432_000),
-    ("10D", "1D", "DM", 864_000),
+    ("4D", "1D", "DM", 345_600),
+    ("8D", "1D", "DM", 691200),
     # Below numbers are estimates, but that is fine;
     # they are only used to estimate the space between ticks
     ("1M", "5D", "MM", 2_592_000),  # days are a bit weird, ah well ...
@@ -532,6 +537,16 @@ class TimeRange:
         # For the winter- to summer-time transition there is a missing hour,
         # which is handled just fine.
         check_summertime_transition = "h" in delta or "m" in delta
+
+        # Special threatment for week zoom-levels, since days align to day-of-month.
+        # When this is a week-view (range and res both include "W") we floor to
+        # week boundaries, and make sure that the delta is 7D.
+        for i in range(len(SCALES)):
+            ran, res, max_nsecs, _ = SCALES[i]
+            if nsecs < max_nsecs:
+                break
+        if ran.indexOf("W") >= 0 and res.indexOf("W") >= 0:
+            delta = "1W"
 
         # Define ticks
         ticks = []


### PR DESCRIPTION
* [x] Introduces a new zoom level at 7 weeks, to compare weeks. Closes #96.
* [x] Centralize the definition of zoom levels and their transition points. This makes that e.g. the changing of the size of the bins in the timeline stats (e.g. it moving from days to multiple days) can be used as a hint for how the timeline will snap. Plus it just removes some more or less duplicate code.
* [x] Add zoom buttons to the time-range popup. 
