### PR TITLE
Tweaks

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -528,12 +528,8 @@ class TimeSelectionDialog(BaseDialog):
         self._t1_input = form.children[1]
         self._t2_input = form.children[3]
 
-        quicknav.children[1].onclick = lambda e: self._apply_quicknav(
-            e.target.innerText
-        )
-        quicknav.children[2].onclick = lambda e: self._apply_quicknav(
-            e.target.innerText
-        )
+        quicknav.children[1].onclick = lambda e: self._apply_quicknav("out")
+        quicknav.children[2].onclick = lambda e: self._apply_quicknav("in")
 
         for i in range(presets.children.length):
             but = presets.children[i]

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -313,15 +313,10 @@ SCALES = [
     ("3h", "5m", 3.6 * 3600, ""),
     ("6h", "5m", 8.5 * 3600, ""),  # Kind of the default view
     ("12h", "1h", 15 * 3600, ""),
-    ("1D", "1h", 3 * 86400, "Day"),
-    ("1W", "1D", 2 * 7 * 86400, "Week"),
-    (
-        "1M",
-        "4D",
-        5.3 * 7 * 86400,
-        "Month",
-    ),  # day-steps is too many, week steps awkward ...
-    ("7W", "1W", 10 * 7 * 86400, "7x7"),
+    ("1D", "1h", 2 * 86400, "Day"),
+    ("1W", "1D", 1.5 * 7 * 86400, "Week"),
+    ("3W", "1W", 3.5 * 7 * 86400, "3x7"),
+    ("1M", "1M", 5.3 * 7 * 86400, "Month"),  # all step sizes are awkward here :)
     ("3M", "1M", 200 * 86400, "Quarter"),
     ("1Y", "1M", 550 * 86400, "Year"),  # step per quarter of month?
     ("2Y", "1M", 1280 * 86400, ""),
@@ -609,7 +604,7 @@ class TimeRange:
         t1, t2 = self.get_range()
         nsecs = t2 - t1
 
-        if nsecs < 3 * 86400:
+        if nsecs < 2 * 86400:
             return None, ""  # Don't draw stats, but records!
 
         for i in range(len(SCALES)):

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -1985,10 +1985,10 @@ class RecordsWidget(Widget):
             ctx.shadowBlur = 0
         elif hover_description:
             ctx.beginPath()
-            ctx.arc(x5 + rne, ty2 - rne, rne, 0.5 * PI, 1.0 * PI)
-            ctx.arc(x5 + rne, ty1 + rne, rne, 1.0 * PI, 1.5 * PI)
-            ctx.arc(x6 - rne, ty1 + rne, rne, 1.5 * PI, 2.0 * PI)
-            ctx.arc(x6 - rne, ty2 - rne, rne, 2.0 * PI, 2.5 * PI)
+            ctx.arc(x5 + rn, ty2 - rn, rn, 0.5 * PI, 1.0 * PI)
+            ctx.arc(x5 + rn, ty1 + rn, rn, 1.0 * PI, 1.5 * PI)
+            ctx.arc(x6 - rn, ty1 + rn, rn, 1.5 * PI, 2.0 * PI)
+            ctx.arc(x6 - rn, ty2 - rn, rn, 2.0 * PI, 2.5 * PI)
             ctx.closePath()
             ctx.shadowBlur = 5
             ctx.shadowColor = COLORS.button_shadow

--- a/timetagger/app/utils.py
+++ b/timetagger/app/utils.py
@@ -824,7 +824,7 @@ class BaseCanvas:
         Returns whether the mouse hovers here now.
         """
         rect = [x1, y1, x2, y2]
-        hash = str(rect)
+        hash = str([int(x1), int(y1), int(x2), int(y2)])
         ob = {"rect": rect, "text": text, "positioning": positioning, "hash": hash}
         self._tooltips.register(x1, y1, x2, y2, ob)
         return self._pointer_hover == ob.hash


### PR DESCRIPTION
Most of this are follow-ups on #97 and #95.

* [x] Fix that the hover state was not active for the running record, and records directly above it.
* [x] Fix that hover state of records showed artifacts in the corners.
* [x] Fix that clicking on the key-hint of the zoom-out button actually zooms in.
* [x] Tweak zoom levels: the 7-week level is replaced for a 3-week level, and the stepsize for the month view is one month. 