### PR TITLE
Fixes to startstop time editing

### DIFF
--- a/tests/test_client_utils.py
+++ b/tests/test_client_utils.py
@@ -254,7 +254,9 @@ def test_timestr2tuple():
     assert timestr2tuple("11:50 pm") == (23, 50, 0)
 
     # Out of range
-    assert timestr2tuple("30") == (24, 0, 0)
+    assert timestr2tuple("30") == (23, 0, 0)
+    assert timestr2tuple("13:60") == (13, 59, 0)
+    assert timestr2tuple("13:24:60") == (13, 24, 59)
 
 
 if __name__ == "__main__":

--- a/tests/test_client_utils.py
+++ b/tests/test_client_utils.py
@@ -253,6 +253,9 @@ def test_timestr2tuple():
     assert timestr2tuple("1pm") == (13, 0, 0)
     assert timestr2tuple("11:50 pm") == (23, 50, 0)
 
+    # Out of range
+    assert timestr2tuple("30") == (24, 0, 0)
+
 
 if __name__ == "__main__":
     run_tests(globals())

--- a/timetagger/app/utils.py
+++ b/timetagger/app/utils.py
@@ -404,7 +404,7 @@ def timestr2tuple(text):
     elif format == "pm" and h < 12:
         h += 12
 
-    return h, m, s
+    return min(h, 23), min(m, 59), min(s, 59)
 
 
 def positions_mean_and_std(positions):


### PR DESCRIPTION
Closes #116 

* Prevents times from overflowing into the next day.
* Prevent snapping the *other* time during editing a time.
* Fixes to when the duration is periodically updated.