### PR TITLE
Fixes to handling maximum input

### DIFF
--- a/tests/test_server_apiserver.py
+++ b/tests/test_server_apiserver.py
@@ -252,7 +252,7 @@ def test_settings():
         # Try adding settings with too long fields
         settings = [
             dict(key="p" * 256, mt=100, value=42),
-            dict(key="pref10", mt=100, value="x" * 256),
+            dict(key="pref10", mt=100, value="x" * 8192),
         ]
         r = p.put(
             "http://localhost/api/v2/settings",

--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -19,6 +19,7 @@ if this_is_js():
     tools = window.tools
     dt = window.dt
     utils = window.utils
+    stores = window.stores
 
 # A stack of dialogs
 stack = []
@@ -1034,7 +1035,7 @@ class RecordDialog(BaseDialog):
         # Unpack so we have all the components
         (
             h1,  # Dialog title
-            _,  # Description header
+            self._ds_header,
             self._ds_container,
             self._preset_container,
             self._tags_div,
@@ -1178,6 +1179,16 @@ class RecordDialog(BaseDialog):
         self._mark_as_edited()
         self._autocomp_init()
         self._show_tags_from_ds()
+        # If the str is too long, limit it
+        if len(self._ds_input.value) >= stores.STR_MAX:
+            self._ds_input.value = self._ds_input.value.slice(0, stores.STR_MAX)
+            if "max" not in self._ds_header.innerHTML:
+                self._ds_header.innerHTML += (
+                    f" <small>(max {stores.STR_MAX-1} chars)</small>"
+                )
+            self._ds_input.style.setProperty("outline", "dashed 2px red")
+            reset = lambda: self._ds_input.style.setProperty("outline", "")
+            window.setTimeout(reset, 2000)
 
     def show_preset_tags(self, e):
         # Prevent that the click will hide the autocomp

--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -1708,9 +1708,11 @@ class TagPresetsDialog(BaseDialog):
         self._input_element.ondragexit = self._on_drop_stop
         self._input_element.ondragover = self._on_drop_over
         self._input_element.ondrop = self._on_drop
+        self._input_element.oninput = self._on_input
 
         self._analysis_out = self.maindiv.children[-2]
 
+        self._description_div = self.maindiv.children[1]
         self._apply_but = self.maindiv.children[2]
         self._apply_but.onclick = self.do_apply
 
@@ -1749,6 +1751,20 @@ class TagPresetsDialog(BaseDialog):
                     reader.readAsText(file)
                     self._analysis_out.innerHTML = f"Read from <u>{file.name}</u>"
                     break  # only process first one
+
+    def _on_input(self):
+        # If the str is too long, limit it
+        if len(self._input_element.value) >= stores.STR_MAX:
+            self._input_element.value = self._input_element.value.slice(
+                0, stores.STR_MAX
+            )
+            if "max" not in self._description_div.innerHTML:
+                self._description_div.innerHTML += (
+                    f"<b>Max {stores.STR_MAX-1} chars.</b>"
+                )
+            self._input_element.style.setProperty("outline", "dashed 2px red")
+            reset = lambda: self._input_element.style.setProperty("outline", "")
+            window.setTimeout(reset, 2000)
 
     def _load_current(self):
         item = window.store.settings.get_by_key("tag_presets")

--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -1708,11 +1708,11 @@ class TagPresetsDialog(BaseDialog):
         self._input_element.ondragexit = self._on_drop_stop
         self._input_element.ondragover = self._on_drop_over
         self._input_element.ondrop = self._on_drop
-        self._input_element.oninput = self._on_input
+        self._input_element.oninput = self._on_edit
+        self._input_element.onchange = self._on_edit
 
         self._analysis_out = self.maindiv.children[-2]
 
-        self._description_div = self.maindiv.children[1]
         self._apply_but = self.maindiv.children[2]
         self._apply_but.onclick = self.do_apply
 
@@ -1752,19 +1752,19 @@ class TagPresetsDialog(BaseDialog):
                     self._analysis_out.innerHTML = f"Read from <u>{file.name}</u>"
                     break  # only process first one
 
-    def _on_input(self):
-        # If the str is too long, limit it
-        if len(self._input_element.value) >= stores.STR_MAX:
-            self._input_element.value = self._input_element.value.slice(
-                0, stores.STR_MAX
-            )
-            if "max" not in self._description_div.innerHTML:
-                self._description_div.innerHTML += (
-                    f"<b>Max {stores.STR_MAX-1} chars.</b>"
-                )
+    def _on_edit(self):
+        # This length estimate is only correct if the tags are formatted
+        # correctly, i.e. no whitespace or non-tag words. The actual
+        # length can only really be obtained by collecting all tags
+        # from the text and stringifying it with json, but that would
+        # be too slow to do on each key press (there can be MANY lines).
+        # We take the normal length, plus 2 per line for quotes, and 4 for braces.
+        length_est = self._input_element.value.length
+        length_est += self._input_element.value.count("\n") * 2 + 4
+        if length_est >= stores.JSON_MAX:
             self._input_element.style.setProperty("outline", "dashed 2px red")
-            reset = lambda: self._input_element.style.setProperty("outline", "")
-            window.setTimeout(reset, 2000)
+        else:
+            self._input_element.style.setProperty("outline", "")
 
     def _load_current(self):
         item = window.store.settings.get_by_key("tag_presets")
@@ -1790,6 +1790,15 @@ class TagPresetsDialog(BaseDialog):
                 line = tags.join(" ")
                 if line:
                     lines2.append(line)
+
+        # Check size
+        length = JSON.stringify(lines2).length
+        if length >= stores.JSON_MAX:
+            self._input_element.style.setProperty("outline", "dashed 2px red")
+            self._analysis_out.innerHTML = (
+                f"Sorry, used {length} of max {stores.JSON_MAX-1} chars."
+            )
+            return
 
         # Save
         item = window.store.settings.create("tag_presets", lines2)

--- a/timetagger/app/stores.py
+++ b/timetagger/app/stores.py
@@ -137,7 +137,7 @@ SETTING_SPEC = dict(key=to_str, mt=to_int, value=to_jsonable)
 SETTING_REQ = ["key", "mt", "value"]
 
 STR_MAX = 256
-
+JSON_MAX = 8192
 
 # ----- END COMMON PART (don't change this comment)
 

--- a/timetagger/server/_apiserver.py
+++ b/timetagger/server/_apiserver.py
@@ -39,7 +39,7 @@ def to_str(s):
 
 def to_jsonable(x):
     s = json.dumps(x)
-    if len(s) >= STR_MAX:
+    if len(s) >= JSON_MAX:
         raise ValueError("Values must be less than 256 chars when jsonized.")
     return x
 
@@ -53,6 +53,7 @@ SETTING_SPEC = dict(key=to_str, mt=to_int, value=to_jsonable)
 SETTING_REQ = ["key", "mt", "value"]
 
 STR_MAX = 256
+JSON_MAX = 8192
 
 # ----- END COMMON PART (don't change this comment)
 


### PR DESCRIPTION
* The record dialog does not allow more than 255 chars, and when it happens a warning occurs. Closes #127.
* The preset dialog does not allow more than 8192 chars`*` (32x as much as before) and warns when its over. Closes #126.

`*` technically the limit applies to the json-serialized version of the preset field.