### PR TITLE
Show presets in autocomp list

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -1191,33 +1191,16 @@ class RecordDialog(BaseDialog):
             reset = lambda: self._ds_input.style.setProperty("outline", "")
             window.setTimeout(reset, 2000)
 
-    def show_preset_tags(self, e):
+    def show_preset_and_recent_tags(self, e):
         # Prevent that the click will hide the autocomp
         if e and e.stopPropagation:
             e.stopPropagation()
-        # Get list of preset strings
-        presets = self._get_suggested_tags_presets()
-        # Produce suggestions
         suggestions = []
-        for preset in presets:
+        # Collect presets
+        for preset in self._get_suggested_tags_presets():
             html = preset + "<span class='meta'>preset<span>"
             suggestions.push((preset, html))
-        # Show
-        val = self._ds_input.value.rstrip()
-        if val:
-            val += " "
-        if suggestions:
-            self._autocomp_state = self._get_autocomp_state()
-            self._autocomp_show("Tag presets:", suggestions)
-        else:
-            self._autocomp_show("No presets defined ...", [])
-
-    def show_recent_tags(self, e):
-        # Prevent that the click will hide the autocomp
-        if e and e.stopPropagation:
-            e.stopPropagation()
-        # Collect recent suggestions
-        suggestions = []
+        # Collect recents
         now = dt.now()
         for tag, tag_t2 in self._suggested_tags_recent:
             date = max(0, int((now - tag_t2) / 86400))
@@ -1227,9 +1210,9 @@ class RecordDialog(BaseDialog):
         # Show
         if suggestions:
             self._autocomp_state = self._get_autocomp_state()
-            self._autocomp_show("Recent tags:", suggestions)
+            self._autocomp_show("Presets & recent tags:", suggestions)
         else:
-            self._autocomp_show("No recent tags ...", suggestions)
+            self._autocomp_show("No presets or recent tags ...", [])
 
     def _autocomp_init(self):
         """Show tag suggestions in the autocompletion dialog."""
@@ -1241,7 +1224,7 @@ class RecordDialog(BaseDialog):
             self._autocomp_clear()
             return
         elif tag_to_be == "#":
-            return self.show_preset_tags()  # Delegate
+            return self.show_preset_and_recent_tags()  # Delegate
 
         # Obtain suggestions
         now = dt.now()
@@ -1298,7 +1281,7 @@ class RecordDialog(BaseDialog):
         # Show
         if suggestions:
             self._autocomp_state = val, i1, i2
-            self._autocomp_show("Matching tags:", suggestions)
+            self._autocomp_show("Matching presets / tags:", suggestions)
         else:
             self._autocomp_clear()
 

--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -1050,7 +1050,6 @@ class RecordDialog(BaseDialog):
         #
         self._ds_input = self._ds_container.children[0]
         self._autocomp_div = self._ds_container.children[1]
-        # self._preset_button = self._preset_container.children[1]
         self._preset_edit = self._preset_container.children[0]
         self._title_div = h1.children[1]
         self._cancel_but1 = self.maindiv.children[0].children[-1]
@@ -1099,7 +1098,6 @@ class RecordDialog(BaseDialog):
         self._resume_but.onclick = self.resume_record
         self._ds_input.oninput = self._on_user_edit
         self._ds_input.onchange = self._on_user_edit_done
-        # self._preset_button.onclick = self.show_preset_tags
         self._preset_edit.onclick = lambda: self._canvas.tag_preset_dialog.open()
         self._delete_but1.onclick = self._delete1
         self._delete_but2.onclick = self._delete2


### PR DESCRIPTION
Closes #137

This is an attempt to fix #137. It seems to work fine, except I don't know how this will work out when you have *a lot* of presets. The way that the autocompletion works is that it only considers one word/tag, so if you type e.g. "#foo #ba", and you have a preset "#foo #bar" and accept it, your text will be "#foo #foo #bar". This will need some thought.