### PR TITLE
Bring back buttons to show recents and presents

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -1016,7 +1016,11 @@ class RecordDialog(BaseDialog):
             </div>
             <div class='container' style='min-height:5px;'>
                 <button type='button' style='float:right; font-size:85%; margin-top:-4px;'>
-                    Presets <i class='fas'>\uf044</i></button>
+                    <i class='fas'>\uf044</i></button>
+                <button type='button' style='float:right; font-size:85%; margin-top:-4px;'>
+                    Presets <i class='fas'>\uf0d7</i></button>
+                <button type='button' style='float:right; font-size:85%; margin-top:-4px;'>
+                    Recent <i class='fas'>\uf0d7</i></button>
             </div>
             <div></div>
             <div style='color:#777;'></div>
@@ -1050,6 +1054,8 @@ class RecordDialog(BaseDialog):
         #
         self._ds_input = self._ds_container.children[0]
         self._autocomp_div = self._ds_container.children[1]
+        self._recent_but = self._preset_container.children[2]
+        self._preset_but = self._preset_container.children[1]
         self._preset_edit = self._preset_container.children[0]
         self._title_div = h1.children[1]
         self._cancel_but1 = self.maindiv.children[0].children[-1]
@@ -1098,6 +1104,8 @@ class RecordDialog(BaseDialog):
         self._resume_but.onclick = self.resume_record
         self._ds_input.oninput = self._on_user_edit
         self._ds_input.onchange = self._on_user_edit_done
+        self._recent_but.onclick = self.show_recents
+        self._preset_but.onclick = self.show_presets
         self._preset_edit.onclick = lambda: self._canvas.tag_preset_dialog.open()
         self._delete_but1.onclick = self._delete1
         self._delete_but2.onclick = self._delete2
@@ -1189,28 +1197,44 @@ class RecordDialog(BaseDialog):
             reset = lambda: self._ds_input.style.setProperty("outline", "")
             window.setTimeout(reset, 2000)
 
-    def show_preset_and_recent_tags(self, e):
+    def show_presets(self, e):
         # Prevent that the click will hide the autocomp
         if e and e.stopPropagation:
             e.stopPropagation()
+        self.show_presets_and_recents(True, False)
+
+    def show_recents(self, e):
+        # Prevent that the click will hide the autocomp
+        if e and e.stopPropagation:
+            e.stopPropagation()
+        self.show_presets_and_recents(False, True)
+
+    def show_presets_and_recents(self, presets=True, recents=True):
         suggestions = []
+        types = []
         # Collect presets
-        for preset in self._get_suggested_tags_presets():
-            html = preset + "<span class='meta'>preset<span>"
-            suggestions.push((preset, html))
+        if presets:
+            types.push("presets")
+            for preset in self._get_suggested_tags_presets():
+                html = preset + "<span class='meta'>preset<span>"
+                suggestions.push((preset, html))
         # Collect recents
-        now = dt.now()
-        for tag, tag_t2 in self._suggested_tags_recent:
-            date = max(0, int((now - tag_t2) / 86400))
-            date = {0: "today", 1: "yesterday"}.get(date, date + " days ago")
-            html = tag + "<span class='meta'>recent: " + date + "<span>"
-            suggestions.push((tag, html))
+        if recents:
+            types.push("recent tags")
+            now = dt.now()
+            for tag, tag_t2 in self._suggested_tags_recent:
+                date = max(0, int((now - tag_t2) / 86400))
+                date = {0: "today", 1: "yesterday"}.get(date, date + " days ago")
+                html = tag + "<span class='meta'>recent: " + date + "<span>"
+                suggestions.push((tag, html))
         # Show
-        if suggestions:
+        if not types:
+            self._autocomp_clear()
+        elif suggestions:
             self._autocomp_state = self._get_autocomp_state()
-            self._autocomp_show("Presets & recent tags:", suggestions)
+            self._autocomp_show(types.join(" & ") + ":", suggestions)
         else:
-            self._autocomp_show("No presets or recent tags ...", [])
+            self._autocomp_show("No " + types.join(" or ") + " ...", [])
 
     def _autocomp_init(self):
         """Show tag suggestions in the autocompletion dialog."""
@@ -1222,7 +1246,7 @@ class RecordDialog(BaseDialog):
             self._autocomp_clear()
             return
         elif tag_to_be == "#":
-            return self.show_preset_and_recent_tags()  # Delegate
+            return self.show_presets_and_recents()  # Delegate
 
         # Obtain suggestions
         now = dt.now()


### PR DESCRIPTION
Closes #161.

<img width="807" alt="image" src="https://user-images.githubusercontent.com/3015475/153948287-981f0aee-0553-4669-bd01-c8cc16ee7eda.png">

I went with separate buttons for recents and presets. That way, the lists are somewhat shorter, which is nice if you really only use the mouse. For ppl using the keyboard its no problem is the list is long because it's combined, because they'll type one or 2 chars and reduce the list to just a few items.