### PR TITLE
Design tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ By making a contribution to this project, you agree to this CLA.
 
 Additional developer dependencies:
 ```
-pip install invoke black flake8 pytest requests
+pip install invoke black flake8 pytest pytest-cov requests
 ```
 
 * `invoke -l` to see available invoke tasks

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -94,6 +94,7 @@ def set_colors():
         COLORS.button_text_disabled = COLORS.prim2_clr
 
         COLORS.record_bg = "#FAFAFA"
+        COLORS.record_bg_running = "#F9F2E1"
         COLORS.record_text = COLORS.prim1_clr
         COLORS.record_edge = COLORS.panel_edge
 
@@ -116,6 +117,7 @@ def set_colors():
         COLORS.button_text_disabled = "#7F838B"
 
         COLORS.record_bg = "#32373E"
+        COLORS.record_bg_running = "#3B3935"
         COLORS.record_text = "#A4B0B8"
         COLORS.record_edge = "#4B4B4B"
 
@@ -2113,11 +2115,11 @@ class RecordsWidget(Widget):
             path.addVertex(x5, ty2, 4)
             path.addVertex(x4, ry2, 4)
         path = path.toPath2D()
-        ctx.fillStyle = COLORS.record_bg
+        ctx.fillStyle = COLORS.record_bg_running if is_running else COLORS.record_bg
         ctx.fill(path)
 
         ctx.strokeStyle = COLORS.record_edge
-        ctx.lineWidth = 2.0 if is_running else 1.2
+        ctx.lineWidth = 1.2
 
         # Draw coloured edge
         tagz = tags.join(" ")

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -83,16 +83,19 @@ def set_colors():
         COLORS.top_bg = COLORS.prim1_clr
 
         COLORS.panel_bg = COLORS.sec1_clr
-        COLORS.panel_edge = COLORS.prim1_clr
+        COLORS.panel_edge = "#BEBFBD"
 
-        COLORS.button_bg = "#fff"
-        COLORS.button_shadow = "rgba(0, 0, 0, 0.4)"
+        COLORS.button_bg = "#FFFFFF"
+        COLORS.button_tag_bg = "#FFFFFF"
+        COLORS.button_shadow = "rgba(0, 0, 0, 0.5)"
+
         COLORS.button_text = COLORS.prim1_clr
+        COLORS.button_tag_text = COLORS.prim1_clr
         COLORS.button_text_disabled = COLORS.prim2_clr
 
-        COLORS.record_bg = "#fafafa"
+        COLORS.record_bg = "#FAFAFA"
         COLORS.record_text = COLORS.prim1_clr
-        COLORS.record_edge = COLORS.prim1_clr
+        COLORS.record_edge = COLORS.panel_edge
 
         window.document.body.classList.remove("darkmode")
 
@@ -102,19 +105,21 @@ def set_colors():
         COLORS.top_bg = COLORS.prim1_clr
 
         COLORS.panel_bg = COLORS.prim1_clr
-        COLORS.panel_edge = "#000"
+        COLORS.panel_edge = "#0A1419"
 
-        COLORS.button_bg = "#bbb"  # COLORS.prim2_clr
-        COLORS.button_shadow = "rgba(0, 0, 0, 0.4)"
-        COLORS.button_text = COLORS.prim1_clr
-        COLORS.button_text_disabled = "#888"
+        COLORS.button_bg = "#32373F"
+        COLORS.button_tag_bg = "#222A32"
+        COLORS.button_shadow = "rgba(0, 0, 0, 0.8)"
 
-        COLORS.record_bg = "rgb(50, 55, 62)"
-        COLORS.record_text = "rgb(170, 170, 170)"
-        COLORS.record_edge = "rgb(75, 75, 75)"
+        COLORS.button_text = "#A4B0B8"
+        COLORS.button_tag_text = "#A4B0B8"
+        COLORS.button_text_disabled = "#7F838B"
+
+        COLORS.record_bg = "#32373E"
+        COLORS.record_text = "#A4B0B8"
+        COLORS.record_edge = "#4B4B4B"
 
         window.document.body.classList.add("darkmode")
-        # window.document.body.style.background = "rgb(0, 0, 0)"
 
 
 def draw_tag(ctx, tag, x, y):
@@ -948,7 +953,7 @@ class TopWidget(Widget):
             updown_w = self._draw_button(
                 ctx,
                 xc,
-                yc - 1.5,
+                yc - 2.5,
                 h,
                 ha,
                 "fas-\uf077",
@@ -959,7 +964,7 @@ class TopWidget(Widget):
             updown_w = self._draw_button(
                 ctx,
                 xc,
-                yc + 1.5,
+                yc + 2.5,
                 h,
                 ha,
                 "fas-\uf078",
@@ -3498,7 +3503,8 @@ class AnalyticsWidget(Widget):
             if action and text.startswith("#"):
                 opt = {
                     "ref": "leftmiddle",
-                    "color": COLORS.button_text,
+                    "color": COLORS.button_tag_text,
+                    "body": COLORS.button_tag_bg,
                     # "padding": 0,
                 }
                 dx = self._draw_button(ctx, tx, ty, None, 30, text, action, tt, opt)


### PR DESCRIPTION
Hi!

I made a few design tweaks, esspecially for the dark mode.

Changes in this PR:
- (darkmode) changes the button color to a dark grey    
this enhances the readability of the tags, especially for the default yellow tag
- increases spacing between `up` and `down` buttons
- (darkmode) really subtle color changes of the widget borders
- visual hint of an actively running record with a different background color    
fixes #159

---
Diffenrece of darkmode changes visualized:
![tt-design](https://user-images.githubusercontent.com/26254821/155913917-c45b9c70-5885-4aff-917c-a103816758f5.gif)

Both variants of colored records (running):
![tt-running](https://user-images.githubusercontent.com/26254821/155914801-cf4776df-23a2-40dc-b256-d8f94946b282.png)
 