### PR TITLE
Lets try turning spellcheck on

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -1011,7 +1011,7 @@ class RecordDialog(BaseDialog):
             </h1>
             <h2><i class='fas'>\uf305</i>&nbsp;&nbsp;Description</h2>
             <div class='container' style='position: relative;'>
-                <input type='text' style='width:100%;' spellcheck='false' />
+                <input type='text' style='width:100%;' spellcheck='true' />
                 <div class='tag-suggestions-autocomp'></div>
             </div>
             <div class='container' style='min-height:5px;'>


### PR DESCRIPTION
Closes #175

Spelling was turned off, because tags are usually not valid spelling. But if you add more text, you'd want that text to be spell-checked. Let's try turning it on.