### PR TITLE
Disable tooltips on touch events

### DIFF
--- a/timetagger/app/utils.py
+++ b/timetagger/app/utils.py
@@ -811,6 +811,7 @@ class BaseCanvas:
         # Only on mouse - it's anoying for touch
         is_mouse = bool(ev.touches["-1"])
         if not is_mouse:
+            self._tooltipdiv.style.display = "none"
             return
         # Get tooltip object - if text is None it means no tooltip
         ob = self._tooltips.pick(x, y)

--- a/timetagger/app/utils.py
+++ b/timetagger/app/utils.py
@@ -808,6 +808,10 @@ class BaseCanvas:
     def _tooltip_handler(self, e):
         ev = create_pointer_event(self.node, e)
         x, y = ev.pos
+        # Only on mouse - it's anoying for touch
+        is_mouse = bool(ev.touches["-1"])
+        if not is_mouse:
+            return
         # Get tooltip object - if text is None it means no tooltip
         ob = self._tooltips.pick(x, y)
         # Handle over. Schedule a new draw if the over-status changes.


### PR DESCRIPTION
They get in the way, and stick around without disappearing.