### PR TITLE
Refactor tag config dialogs

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -1682,11 +1682,11 @@ class TagComboDialog(BaseDialog):
             <h1><i class='fas'>\uf02c</i>&nbsp;&nbsp;Tag combo {tagz}
                 <button type='button'><i class='fas'>\uf00d</i></button>
                 </h1>
-            <h2>Individual tags</h2>
+            <h2><i class='fas'>\uf02c</i>&nbsp;&nbsp;Tags</h2>
             <div>buttons for tags go here</div>
-            <h2>Combo target</h2>
+            <h2><i class='fas'>\uf140</i>&nbsp;&nbsp;Target</h2>
             <div>target goes here</div>
-            <h2>Manage</h2>
+            <h2><i class='fas'>\uf101</i>&nbsp;&nbsp;More</h2>
             <div>
                 TODO
             </div>
@@ -1757,18 +1757,16 @@ class TagDialog(BaseDialog):
             <h1><i class='fas'>\uf02b</i>&nbsp;&nbsp;Configure tag {tagz}
                 <button type='button'><i class='fas'>\uf00d</i></button>
                 </h1>
-            <h2>Tag target</h2>
+            <h2><i class='fas'>\uf140</i>&nbsp;&nbsp;Target</h2>
             <div>target goes here</div>
-            <h2>Tag color</h2>
-            <div>
-                <input type='text' style='width: 210px; border: 5px solid #eee' spellcheck='false' />
-                <br>
-                <button type='button'><i class='fas'>\uf12d</i> Default</button>
-                <button type='button' style='margin-left: 2px'><i class='fas'>\uf2f1</i> Random</button>
-                <br>
-                <div style='display: inline-grid; grid-gap: 2px;'></div>
-            </div>
-            <h2>Manage</h2>
+            <h2><i class='fas'>\uf53f</i>&nbsp;&nbsp;Color</h2>
+            <input type='text' style='width: 210px; border: 5px solid #eee' spellcheck='false' />
+            <br>
+            <button type='button'><i class='fas'>\uf12d</i> Default</button>
+            <button type='button' style='margin-left: 2px'><i class='fas'>\uf2f1</i> Random</button>
+            <br>
+            <div style='display: inline-grid; grid-gap: 2px;'></div>
+            <h2><i class='fas'>\uf101</i>&nbsp;&nbsp;More</h2>
             <div>
                 TODO
             </div>
@@ -1786,21 +1784,17 @@ class TagDialog(BaseDialog):
             _,  # target header
             target_div,
             _,  # color header
-            color_div,
-            _,  # manage header
-            manage_div,
-            _,  # gap
-            finish_buttons,
-        ) = self.maindiv.children
-
-        (
             self._color_input,
             _,  # br
             self._color_default_button,
             self._color_random_button,
             _,  # br
             self._color_grid,
-        ) = color_div.children
+            _,  # manage header
+            manage_div,
+            _,  # gap
+            finish_buttons,
+        ) = self.maindiv.children
 
         self._target = TargetHelper(tags, target_div)
 

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -154,15 +154,14 @@ class TimeTaggerCanvas(BaseCanvas):
         self.timeselection_dialog = dialogs.TimeSelectionDialog(self)
         self.settings_dialog = dialogs.SettingsDialog(self)
         self.record_dialog = dialogs.RecordDialog(self)
-        self.tag_color_selection_dialog = dialogs.TagColorSelectionDialog(self)
-        self.tag_color_dialog = dialogs.TagColorDialog(self)
+        self.tag_combo_dialog = dialogs.TagComboDialog(self)
+        self.tag_dialog = dialogs.TagDialog(self)
         self.report_dialog = dialogs.ReportDialog(self)
         self.tag_preset_dialog = dialogs.TagPresetsDialog(self)
         self.tag_manage_dialog = dialogs.TagManageDialog(self)
         self.export_dialog = dialogs.ExportDialog(self)
         self.import_dialog = dialogs.ImportDialog(self)
         self.pomodoro_dialog = dialogs.PomodoroDialog(self)
-        self.targets_dialog = dialogs.TargetsDialog(self)
 
         # The order here is also the draw-order. Records must come after analytics.
         self.widgets = {
@@ -3386,7 +3385,7 @@ class AnalyticsWidget(Widget):
                 y2,
                 ex,
                 y3,
-                {"button": True, "action": "chosecolor:" + unit.tagz},
+                {"button": True, "action": "configure_tags:" + unit.tagz},
             )
             tt_text = "Color for " + unit.tagz + "\n(Click to change color)"
             hover = self._canvas.register_tooltip(
@@ -3430,12 +3429,14 @@ class AnalyticsWidget(Widget):
             if len(self.selected_tags):
                 tx = unit.x2 + 11
                 texts.push([" ←  back to all ", "select:", "Full overview"])
-                if len(self.selected_tags) > 0:
-                    action = "chosetargets:" + self.selected_tags.join(" ")
-                    texts.push(["fas-\uf140", action, "Set targets"])
-                if len(self.selected_tags) == 1:
-                    action = "chosecolor:" + self.selected_tags[0]
-                    texts.push(["fas-\uf53f", action, "Select a different color"])
+                if len(self.selected_tags) == 0:
+                    pass
+                elif len(self.selected_tags) == 1:
+                    action = "configure_tag:" + self.selected_tags[0]
+                    texts.push(["fas-\uf02b", action, "Configure tag"])
+                else:
+                    action = "configure_tags:" + self.selected_tags.join(" ")
+                    texts.push(["fas-\uf02c", action, "Configure tag combo"])
             else:
                 ctx.textAlign = "right"
                 ctx.fillText(duration, x_ref_duration, ty)
@@ -3541,16 +3542,12 @@ class AnalyticsWidget(Widget):
                             self.selected_tags.push(tag)
                     else:
                         self.selected_tags = []
-                elif picked.action.startswith("chosecolor:"):
+                elif picked.action.startswith("configure_tag:"):
                     _, _, tagz = picked.action.partition(":")
-                    tags = tagz.split(" ")
-                    if len(tags) == 1:
-                        self._canvas.tag_color_dialog.open(tags[0], self.update)
-                    elif len(tags) > 1:
-                        self._canvas.tag_color_selection_dialog.open(tags, self.update)
-                elif picked.action.startswith("chosetargets:"):
+                    self._canvas.tag_dialog.open(tagz, self.update)
+                elif picked.action.startswith("configure_tags:"):
                     _, _, tagz = picked.action.partition(":")
-                    self._canvas.targets_dialog.open(tagz, self.update)
+                    self._canvas.tag_combo_dialog.open(tagz, self.update)
                 self.update()
 
 


### PR DESCRIPTION
Replaces the separate tag-color dialog and target-dialog with two new dialogs: one for tag combis and one for individual tags.

This closes #139. It forms the basis for more improvements, e.g.:
* A rename button.
* A button to see all records for that tag/tag combi, as discussed in #139.
* Setting tag priority #128 
* Improved targets / multiple targets #121 

<img width="794" alt="image" src="https://user-images.githubusercontent.com/3015475/160916658-68b2c082-8102-4a78-85f2-443698e15ab7.png">
