### PR TITLE
Add tag priority feature

### DIFF
--- a/tests/test_client_utils.py
+++ b/tests/test_client_utils.py
@@ -229,6 +229,14 @@ def test_get_better_tag_order_from_stats():
     stats2 = get_better_tag_order(stats, [], False, priorities)
     assert stats2 == stats2_ref
 
+    # But selected tags override
+    priorities = {"#client1": 1, "#client2": 1, "#code": 2, "#admin": 2}
+    stats2 = get_better_tag_order(stats, ["#code"], False, priorities)
+    assert stats2 == [
+        "#code #client1",
+        "#code #client2",
+    ]
+
 
 def test_timestr2tuple():
     assert timestr2tuple("") == (None, None, None)

--- a/tests/test_client_utils.py
+++ b/tests/test_client_utils.py
@@ -192,6 +192,43 @@ def test_get_better_tag_order_from_stats():
         "#client3 #code",
     ]
 
+    # Priority - first the reason why we have it: unwanted grouping
+    stats = {
+        "#client1 #code": 5280,
+        "#client2 #code": 4680,
+        "#client1 #admin": 20,
+        "#client2 #admin": 10,
+    }
+    stats2 = get_better_tag_order(stats, [], False)
+    assert stats2 == [
+        "#code #client1",
+        "#code #client2",
+        "#admin #client1",
+        "#admin #client2",
+    ]
+
+    # Now fix it
+    # Note that the function order_stats_by_duration_and_name() is not called
+    # in these tests. That function will make the order of the tagz correct.
+    # What we test here is only the order of tags in one tagz.
+    priorities = {"#client1": 1, "#client2": 1, "#code": 2, "#admin": 2}
+    stats2 = get_better_tag_order(stats, [], False, priorities)
+    stats2_ref = [
+        "#client1 #code",
+        "#client2 #code",
+        "#client1 #admin",
+        "#client2 #admin",
+    ]
+    assert stats2 == stats2_ref
+    # Should also work
+    priorities = {"#code": 2}
+    stats2 = get_better_tag_order(stats, [], False, priorities)
+    assert set(stats2) == set(stats2_ref)
+    # Should also work
+    priorities = {"#client1": 3, "#client2": 3, "#code": 4, "#admin": 4}
+    stats2 = get_better_tag_order(stats, [], False, priorities)
+    assert stats2 == stats2_ref
+
 
 def test_timestr2tuple():
     assert timestr2tuple("") == (None, None, None)

--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -1635,23 +1635,23 @@ class TargetHelper:
         self._hour_input, _, self._period_select = div.children
 
     def load_from_info(self, info):
-        targets = info.get("targets", [])
-        if not targets:
-            self._hour_input.value = 1
-            self._period_select.value = "none"
-        else:
-            target = targets[0]
-            self._hour_input.value = target.hours or 1
-            self._period_select.value = target.period or "none"
+        targets = info.get("targets", None) or {}
+        for period, hours in targets.items():
+            if period and hours:
+                self._hour_input.value = hours or 1
+                self._period_select.value = period or "none"
+                break
+            else:
+                self._hour_input.value = 0
+                self._period_select.value = "none"
 
     def write_to_info(self, info):
-        targets = []
+        targets = {}
 
-        target = {}
-        target.hours = float(self._hour_input.value)
-        target.period = self._period_select.value
-        if target.hours > 0 and target.period and target.period != "none":
-            targets.push(target)
+        hours = float(self._hour_input.value)
+        period = self._period_select.value
+        if hours > 0 and period and period != "none":
+            targets[period] = hours
 
         info.targets = targets
 

--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -1757,7 +1757,7 @@ class TagDialog(BaseDialog):
             <div>target goes here</div>
             <h2><i class='fas'>\uf074</i>&nbsp;&nbsp;Priority</h2>
             <select>
-                <option value='1'>Primary (default, determines order)</option>
+                <option value='1'>Primary (default)</option>
                 <option value='2'>Secondary (for "extra" tags)</option>
             </select>
             <h2><i class='fas'>\uf53f</i>&nbsp;&nbsp;Color</h2>

--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -1864,7 +1864,7 @@ class TagDialog(BaseDialog):
         # Set target
         self._target.write_to_info(info)
         # Set priority
-        prio = self._priority_select.value
+        prio = int(self._priority_select.value)
         info["priority"] = 0 if prio == 1 else prio
         # Set color
         clr = self._color_input.value
@@ -2431,8 +2431,18 @@ class ReportDialog(BaseDialog):
         records = window.store.records.get_records(t1, t2).values()
         records.sort(key=lambda record: record.t1)
 
+        # Determine priorities
+        priorities = {}
+        for tagz in stats.keys():
+            tags = tagz.split(" ")
+            for tag in tags:
+                info = window.store.settings.get_tag_info(tag)
+                priorities[tag] = info.get("priority", 0) or 1
+
         # Get better names
-        name_map = utils.get_better_tag_order_from_stats(stats, self._tags, True)
+        name_map = utils.get_better_tag_order_from_stats(
+            stats, self._tags, True, priorities
+        )
 
         # Create list of pairs of stat-name, stat-key, and sort.
         # Thid is the reference order for tagz.

--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -2377,10 +2377,17 @@ class ReportDialog(BaseDialog):
         #
         grouping = window.localsettings.get("report_grouping", "date")
         self._grouping_select.value = grouping
-        self._grouping_select.onchange = self._on_grouping_changed
-        self._hidesecondary_but.oninput = self._update_table
-        self._hourdecimals_but.oninput = self._update_table
-        self._showrecords_but.oninput = self._update_table
+        hidesecondary = window.localsettings.get("report_hidesecondary", False)
+        self._hidesecondary_but.checked = hidesecondary
+        hourdecimals = window.localsettings.get("report_hourdecimals", False)
+        self._hourdecimals_but.checked = hourdecimals
+        showrecords = window.localsettings.get("report_showrecords", True)
+        self._showrecords_but.checked = showrecords
+        #
+        self._grouping_select.onchange = self._on_setting_changed
+        self._hidesecondary_but.oninput = self._on_setting_changed
+        self._hourdecimals_but.oninput = self._on_setting_changed
+        self._showrecords_but.oninput = self._on_setting_changed
         #
         self._copy_but.onclick = self._copy_clipboard
         self._savecsv_but.onclick = self._save_as_csv
@@ -2389,8 +2396,13 @@ class ReportDialog(BaseDialog):
         window.setTimeout(self._update_table)
         super().open(None)
 
-    def _on_grouping_changed(self):
+    def _on_setting_changed(self):
         window.localsettings.set("report_grouping", self._grouping_select.value)
+        window.localsettings.set(
+            "report_hidesecondary", self._hidesecondary_but.checked
+        )
+        window.localsettings.set("report_hourdecimals", self._hourdecimals_but.checked)
+        window.localsettings.set("report_showrecords", self._showrecords_but.checked)
         self._update_table()
 
     def _update_table(self):

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -2982,9 +2982,17 @@ class AnalyticsWidget(Widget):
             for tag in tags:
                 self._time_per_tag[tag] = self._time_per_tag.get(tag, 0) + t
 
+        # Determine priorities
+        priorities = {}
+        for tagz in stats.keys():
+            tags = tagz.split(" ")
+            for tag in tags:
+                info = window.store.settings.get_tag_info(tag)
+                priorities[tag] = info.get("priority", 0) or 1
+
         # Get better names (order of tags in each tag combo)
         name_map = utils.get_better_tag_order_from_stats(
-            stats, self.selected_tags, False
+            stats, self.selected_tags, False, priorities
         )
         self.tagzmap.update(name_map)
 

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -2371,14 +2371,22 @@ class RecordsWidget(Widget):
         sumcount_nominal = 0
         sumcount_selected = 0
         for tagz, count in stats_dict.items():
-            tags = tagz.split(" ")
-            sumcount_full += count * len(tags)
+            # Get tags list, tags2 filters out the secondary tags
+            tags1 = tagz.split(" ")
+            tags2 = []
+            for tag in tags1:
+                info = window.store.settings.get_tag_info(tag)
+                if info.get("priority", 1) <= 1:
+                    tags2.push(tag)
+            # Update sums
+            sumcount_full += count * len(tags2)
             sumcount_nominal += count
+            # Filter selected (mind to test against tags1 here)
             if len(selected_tags):
-                if not all([tag in tags for tag in selected_tags]):
+                if not all([tag in tags1 for tag in selected_tags]):
                     continue
             sumcount_selected += count
-            for tag in tags:
+            for tag in tags2:
                 tag_stats[tag] = tag_stats.get(tag, 0) + count
 
         # Turn stats into tuples and sort.

--- a/timetagger/app/stores.py
+++ b/timetagger/app/stores.py
@@ -335,18 +335,18 @@ class SettingsStore(BaseStore):
 
     def get_tag_info(self, tagz):
 
-        info = {"targets": []}
+        info = {"targets": {}}
 
         # Load color the old way. We can remove this in about a year or so (2023)
         ob = self.get_by_key("color " + tagz)
         if ob is not None and ob.value:
             info["color"] = ob.value
 
-        # Dito for the targets
+        # Load targets the old way
         item = self._items.get("tag_targets", None) or {"value": {}}
         target = item.value.get(tagz, None)
         if target:
-            info["targets"].push(target)
+            info["targets"][target.period] = target.hours
 
         # Load the actual data
         key = "taginfo " + tagz

--- a/timetagger/app/stores.py
+++ b/timetagger/app/stores.py
@@ -315,19 +315,51 @@ class SettingsStore(BaseStore):
         for item in settings:
             self._items[item.key] = item
 
-    def set_color_for_tag(self, tag, color):
-        key = "color " + tag
-        ob = self.create(key, color)
+    def set_tag_info(self, tagz, info):
+        key = "taginfo " + tagz
+
+        # Check if any value is set
+        any_nonempty = False
+        for value in info.values():
+            if value:
+                any_nonempty = True
+                break
+
+        # Maybe there is no need to actually set the info
+        if (not any_nonempty) and (not self._items.get(key, None)):
+            return
+
+        # Apply
+        ob = self.create(key, info)
         self.put(ob)
 
-    def get_color_for_tag(self, tag):
-        key = "color " + tag
-        ob = self.get_by_key(key)
+    def get_tag_info(self, tagz):
+
+        info = {"targets": []}
+
+        # Load color the old way. We can remove this in about a year or so (2023)
+        ob = self.get_by_key("color " + tagz)
         if ob is not None and ob.value:
-            return ob.value
-        else:
-            return window.front.COLORS.acc_clr
-            # return utils.color_from_name(tag)
+            info["color"] = ob.value
+
+        # Dito for the targets
+        item = self._items.get("tag_targets", None) or {"value": {}}
+        target = item.value.get(tagz, None)
+        if target:
+            info["targets"].push(target)
+
+        # Load the actual data
+        key = "taginfo " + tagz
+        ob = self.get_by_key(key)
+        if ob is not None:
+            info.update(ob.value)
+
+        return info
+
+    def get_color_for_tag(self, tag):
+        info = self.get_tag_info(tag)
+        color = info.get("color", "")
+        return color or window.front.COLORS.acc_clr
 
 
 class RecordStore(BaseStore):
@@ -981,7 +1013,7 @@ class DemoDataStore(BaseDataStore):
             "#client2": "#429270",
         }
         for tag, color in colors.items():
-            self.settings.set_color_for_tag(tag, color)
+            self.settings.set_tag_info(tag, {"color": color})
 
     def _create_tags(self):
 

--- a/timetagger/app/utils.py
+++ b/timetagger/app/utils.py
@@ -235,32 +235,32 @@ def get_better_tag_order_from_stats(
             if all([tag in tags for tag in selected_tags]):
                 stats[tagz] = ori_stats[tagz]
 
-    # We have two scores, both apply to individual tags.
-
-    # Score 1: A score based on duration, so we can sort them later.
+    # We have three scores, in increasing importance. Each applies to individual tags.
+    depth = 0  # Used down below
     tag_scores1 = {}
-    depth = 0
-    for tagz, t in stats.items():
+    tag_scores2 = {}
+    tag_scores3 = {}
+    for tagz in stats.keys():
         tags = tagz.split(" ")
         depth = max(depth, len(tags))
         for tag in tags:
-            tag_scores1[tag] = tag_scores1.get(tag, 0) + t
+            tag_scores1[tag] = 0
+            tag_scores2[tag] = 0
+            tag_scores3[tag] = 0
 
-    # Correction: Make sure that selected tags have the best scores
-    for i, tag in enumerate(selected_tags):
-        d = 1000 + len(selected_tags) - i
-        tag_scores1[tag] = tag_scores1.get(tag, 0) + d
+    # Score 1: A score based on duration.
+    for tagz, t in stats.items():
+        for tag in tagz.split(" "):
+            tag_scores1[tag] = tag_scores1.get(tag, 0) + t
 
     # Score 2: A score based on how often a tag occurs.
     # This works by letting each tag deal out points to other tags that
     # it occurs with together, which gives a nicer result than just
-    # counting occurances. This is actually the more important score.
-    tag_scores2 = {}
+    # counting occurances.
     tag_connections = {}
     for tagz, t in stats.items():
         for tag in tagz.split(" "):
             tag_connections[tag] = tag_connections.get(tag, 0) + 1
-            tag_scores2[tag] = 1000  # init
     for tagz, t in stats.items():
         tags = tagz.split(" ")
         for tag in tags:
@@ -268,12 +268,14 @@ def get_better_tag_order_from_stats(
                 if tag2 != tag:
                     tag_scores2[tag2] += 1 / tag_connections[tag]
 
-    # Correction: Make sure that higher priority (lower number) tags come first
+    # Score 3: A score based on priority and selection. Overrides the other scores.
     if priorities is not None:
-        for tag, score2 in tag_scores2.items():
+        for tag in tag_scores3.keys():
             priority = priorities.get(tag, 0) or 1
-            d = -100 * priority
-            tag_scores2[tag] = score2 + d
+            tag_scores3[tag] -= min(priority, 10)
+    for i, tag in enumerate(selected_tags):
+        d = 100 - i * 10
+        tag_scores3[tag] = tag_scores3.get(tag, 0) + d
 
     # Sort the tagz (tag combis), based on the tag_scores.
     # This will be the order for the renaming process. This is important,
@@ -282,17 +284,20 @@ def get_better_tag_order_from_stats(
     for tagz in stats.keys():
         score1 = 0
         score2 = 0
+        score3 = 0
         for tag in tagz.split(" "):
             score1 += tag_scores1[tag]
             score2 += tag_scores2[tag]
-        sorted_tagz.append((tagz, score1, score2))
+            score3 += tag_scores3[tag]
+        sorted_tagz.append((tagz, score1, score2, score3))
     sorted_tagz.sort(key=lambda x: -x[1])
     sorted_tagz.sort(key=lambda x: -x[2])
+    sorted_tagz.sort(key=lambda x: -x[3])
 
     # Rename the tagz (change tag order) based on the tag score
     name_map = {}
     position_votes = {}
-    for tagz, _, _ in sorted_tagz:
+    for tagz, _, _, _ in sorted_tagz:
         tags = tagz.split(" ")
         # Optionally clear the list from selected tags
         if remove_selected:
@@ -308,6 +313,7 @@ def get_better_tag_order_from_stats(
             i += 1
             remaining_tags.sort(key=lambda tag: -tag_scores1[tag])
             remaining_tags.sort(key=lambda tag: -tag_scores2[tag])
+            remaining_tags.sort(key=lambda tag: -tag_scores3[tag])
             remaining_tags.sort(key=lambda tag: -position_votes.get(str(i) + tag, 0))
             tags.append(remaining_tags.pop(0))
         name_map[tagz] = " ".join(tags)


### PR DESCRIPTION
Closes #128, by introducing tag-priority, and enabling hiding secondary tags in the report. This PR also lays the basis for #121, by making it possible to store multiple targets per tag.

* [x] Refactor how we store per-tag info. Colors and targets were stored in different ways. Now tag-info is stored together. The old info should still be read correctly.
* [x] Add priority selection to tag dialog.
* [x] Update sorting mechanism to use priority.
* [x] Tests.
* [x] Update logic that shows the targets.
* [x] Update report dialog to take priority into account.
* [x] Update report dialog to hide secondary tags.
* [x] Fix weird behavior when selecting a secondary tag.
* [x] Change how targets are stored (use dict instead of list).
* [x] Self-review.
* [x] Deploy to staging, and verify that personal colors and targets are preserved.
* [x] Also filter out secondary tags in the coloured bands in the timeline's high-level view. See #189.
  