### PR TITLE
Fix layout regression

### DIFF
--- a/timetagger/app/app.scss
+++ b/timetagger/app/app.scss
@@ -3,7 +3,7 @@ body.darkmode { background: $bg3; }
 
 #canvas {
     position: absolute;
-    top: 0; left: 0; bottom: 0; right: 0; width: 100vw; height: 100vh;
+    top: 0; left: 0; bottom: 0; right: 0; width: 100%; height: 100vh;
     border: 0; margin: 0; padding: 0; outline: none;
     box-shadow: 0 0 4px rgba(0, 0, 0, 0.4);
     border-radius: 2px;


### PR DESCRIPTION
Due to the fix in #198, on wider screens, the layout was incorrect. This fixes it by only using the viewport measure only for the height.