### PR TITLE
Fix clicking on autocomp option

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -1207,7 +1207,7 @@ class Autocompleter:
             item.classList.add("tag-suggestion")
             item.innerHTML = html
             onclick = f'window._autocomp_finish("{text}");'
-            item.setAttribute("onclick", onclick)
+            item.setAttribute("onmousedown", onclick)
             self._div.appendChild(item)
         # Show
         self._div.hidden = False


### PR DESCRIPTION
Closes #212. In #210 I changed how the autocomplete dialog closed itself when the input lost focus, but that prevented triggering the onclick event. It still works with mousedown tho.