### PR TITLE
Return focus to canvas when a dialog is closed

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -268,6 +268,8 @@ class BaseDialog:
                 break
         else:
             show_background_div(False)
+            window.canvas.node.focus()  # See #243
+
         # Fire callback
         if self._callback is not None:
             self._callback()


### PR DESCRIPTION
Closes #243. This will probably do the trick. I confirmed that previously the input element has focus, even though the dialog is gone. With this change the canvas gets focus once the (last) dialog is closed.