### PR TITLE
Fix bug in search dialog

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -2382,7 +2382,7 @@ class SearchDialog(BaseDialog):
                 if not all_tags_ok:
                     continue
                 # Check strings
-                ds = record.ds.lower()
+                ds = (record.ds or "").lower()
                 all_strings_ok = True
                 for word in search_strings:
                     if word not in ds:


### PR DESCRIPTION
When searching for plain text in the search dialog, I observed an error because some records may not have a description. This PR fixes that.