### PR TITLE
Added link to blog article on autostarting TimeTagger.

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -37,5 +37,7 @@ comply to the TimeTagger license (GPLv3).
 
 Also check [this article](https://timetagger.app/articles/selfhost/) about self-hosting TimeTagger.
 
+For more on autostarting TimeTagger on Linux systems, read [this article](https://tderflinger.com/en/using-systemd-to-start-a-python-application-with-virtualenv).
+
 If you're interested in including TimeTagger into a larger product,
 contact [me](https://almarklein.org) for information about an OEM license.


### PR DESCRIPTION
Hi Almar,

as per your suggestion, I added a link to my blog article for autostarting TimeTagger on Linux using systemd. 

Greetings,
-Thomas