### PR TITLE
Use iptools to allow specification of CIDR IP ranges

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyjwt
 jinja2
 markdown
 bcrypt
+iptools

--- a/timetagger/__main__.py
+++ b/timetagger/__main__.py
@@ -234,7 +234,8 @@ def load_credentials():
 
 
 def load_trusted_proxies():
-    return iptools.IpRangeList(*[s.strip() for s in config.proxy_auth_trusted.replace(";", ",").split(",")])
+    ips = [s.strip() for s in config.proxy_auth_trusted.replace(";", ",").split(",")]
+    return iptools.IpRangeList(*ips)
 
 
 CREDENTIALS = load_credentials()

--- a/timetagger/__main__.py
+++ b/timetagger/__main__.py
@@ -29,6 +29,7 @@ import bcrypt
 import asgineer
 import itemdb
 import pscript
+import iptools
 import timetagger
 from timetagger import config
 from timetagger.server import (
@@ -233,7 +234,7 @@ def load_credentials():
 
 
 def load_trusted_proxies():
-    return [s.strip() for s in config.proxy_auth_trusted.replace(";", ",").split(",")]
+    return iptools.IpRangeList(*[s.strip() for s in config.proxy_auth_trusted.replace(";", ",").split(",")])
 
 
 CREDENTIALS = load_credentials()

--- a/timetagger/_config.py
+++ b/timetagger/_config.py
@@ -24,8 +24,8 @@ class Config:
       You can generate credentials with https://timetagger.app/cred.
     * `proxy_auth_enabled (bool)`: enables authentication from a reverse proxy
       (for example Authelia). Default "False".
-    * `proxy_auth_trusted (str)`: list of trusted reverse proxy IPs, in the
-      form "127.0.0.1,10.0.0.1". Default "127.0.0.1".
+    * `proxy_auth_trusted (str)`: list of trusted reverse proxy IPs with or without CIDR, in the
+      form "127.0.0.1,10.0.0.1,10.99.0.0/24,192.168/16". Default "127.0.0.1".
     * `proxy_auth_header (str)`: name of the proxy header which contains the
       username of the logged in user. Default "X-Remote-User".
 


### PR DESCRIPTION
Allowing CIDR-ranges in the TRUSTED_PROXIES specification makes it easy to specify a range of trusted IP addresses.
My use case being the proxy auth frontend and timetagger both running in kubernetes where the pods/containers get a random IP address within a specified subnet which would make it tedious to specify them one-by-one.

Specifying `proxy_auth_trusted` works exactly like before, with the exception that iptools handles parsing to allow CIDR addresses.

A ready-made container which I used to test the changes in my kubernetes cluster is available at https://hub.docker.com/r/rynoxx/timetagger


[iptools source](https://github.com/bd808/python-iptools)
[iptools documentation](https://python-iptools.readthedocs.io/en/latest/)
