### PR TITLE
Better support for running records with a negative duration

### DIFF
--- a/timetagger/app/dt.py
+++ b/timetagger/app/dt.py
@@ -268,11 +268,13 @@ def add(t, delta):
 def duration_string_colon(t, show_secs=False):
     PSCRIPT_OVERLOAD = False  # noqa
     # Note the floor-rounding for all but the last element
+    sign = "-" if t < 0 else ""
+    t = abs(t)
     if show_secs:
-        return f"{t//3600:.0f}:{(t//60)%60:02.0f}:{t%60:02.0f}"
+        return f"{sign}{t//3600:.0f}:{(t//60)%60:02.0f}:{t%60:02.0f}"
     else:
         m = Math.round(t / 60)
-        return f"{m//60:.0f}:{m%60:02.0f}"
+        return f"{sign}{m//60:.0f}:{m%60:02.0f}"
 
 
 def duration_string(t, show_secs=False):
@@ -281,20 +283,22 @@ def duration_string(t, show_secs=False):
     if window.simplesettings:
         repr = window.simplesettings.get("duration_repr", "hms")
     if repr == "hms":
+        sign = "-" if t < 0 else ""
+        t = abs(t)
         if show_secs:
             m = (t // 60) % 60
             h = t // 3600
             if h:
-                return f"{h:.0f}h{m:02.0f}m{t%60:02.0f}s"
+                return f"{sign}{h:.0f}h{m:02.0f}m{t%60:02.0f}s"
             else:
-                return f"{m:.0f}m{t%60:02.0f}s"
+                return f"{sign}{m:.0f}m{t%60:02.0f}s"
         else:
             m = Math.round(t / 60)
             h = m // 60
             if h:
-                return f"{h:.0f}h{m%60:02.0f}m"
+                return f"{sign}{h:.0f}h{m%60:02.0f}m"
             else:
-                return f"{m%60:.0f}m"
+                return f"{sign}{m%60:.0f}m"
     else:
         return duration_string_colon(t, show_secs)
 

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -2310,6 +2310,8 @@ class RecordsWidget(Widget):
         ry2 = y0 + npixels * (record.t2 - t1) / nsecs
         if record.t1 == record.t2:
             ry2 = y0 + npixels * (self._canvas.now() - t1) / nsecs
+        if ry1 > ry2:
+            ry1, ry2 = ry2, ry1
         ry1 = grid_round(ry1)
         ry2 = grid_round(ry2)
 


### PR DESCRIPTION
Closes  #315

* Time is displayed as `-20m10s` instead of something like `-20m-10s` with numbers that are not correct.
* You can drag the flap op the record in the timeline. When you do this, the time snaps to now.