### PR TITLE
Fixes to autocomp

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -1279,6 +1279,7 @@ class Autocompleter:
             item.setAttribute("onmousedown", onclick)
             self._div.appendChild(item)
         # Show
+        self._select_does_replace = "descriptions" in headline
         self._div.hidden = False
         self._make_active(0)
 
@@ -1311,7 +1312,7 @@ class Autocompleter:
     def _finish(self, text):
         self.clear()
         if text:
-            if not text.startswith("#"):
+            if self._select_does_replace:
                 # Recent ds, just replace the whole thing
                 self._input.value = text
                 self._input.selectionStart = self._input.selectionEnd = len(text)

--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -1275,7 +1275,7 @@ class Autocompleter:
             item = document.createElement("div")
             item.classList.add("tag-suggestion")
             item.innerHTML = html
-            onclick = f"window._autocomp_finish({i});"
+            onclick = f"window._autocomp_finish(event, {i});"
             item.setAttribute("onmousedown", onclick)
             self._div.appendChild(item)
         # Show
@@ -1301,8 +1301,12 @@ class Autocompleter:
         # Make corresponding item visible
         active_child.scrollIntoView({"block": "nearest"})
 
-    def _finish_cb(self, i):
+    def _finish_cb(self, e, i):
+        # Called when the autocomp item is clicked
         self._finish(self._suggested_tags_in_autocomp[i])
+        if e and e.stopPropagation:
+            e.stopPropagation()
+            e.preventDefault()
 
     def _finish(self, text):
         self.clear()


### PR DESCRIPTION
Closes #335.

Also closes an issue where selecting an item from the recent descriptions, the text is not replaced but appended. The problem was the test `if not text.startswith("#")` which intended to check whether the new text was an earlier description, but this of course fails for descriptions that simply start with a tag 🤷 . Now we track whether the autocomp list comtains descriptions and use that flag. 