### PR TITLE
Switch containers to unpriviliged service user

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -24,18 +24,36 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN  }}
 
+      # Build default priviliged container image version
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository }}
           tags: type=ref,event=tag
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: deploy/repo.Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      # Build non-root container image variant
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta-nonroot
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: type=ref,event=tag,suffix=-nonroot
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: deploy/repo.Dockerfile
+          push: true
+          tags: ${{ steps.meta-nonroot.outputs.tags }}
+          labels: ${{ steps.meta-nonroot.outputs.labels }}

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -18,6 +18,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Log in to GitHub container registry
         uses: docker/login-action@v2
         with:
@@ -36,6 +42,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: deploy/repo.Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -47,6 +54,12 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Log in to GitHub container registry
         uses: docker/login-action@v2
@@ -66,6 +79,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: deploy/repo.nonroot.Dockerfile
           push: true
           tags: ${{ steps.meta-nonroot.outputs.tags }}

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -11,7 +11,8 @@ permissions:
   packages: write
 
 jobs:
-  docker:
+  # Build default priviliged container image version
+  docker-root:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -24,7 +25,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN  }}
 
-      # Build default priviliged container image version
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
@@ -41,7 +41,20 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      # Build non-root container image variant
+  # Build non-root container image variant
+  docker-nonroot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to GitHub container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN  }}
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta-nonroot
         uses: docker/metadata-action@v4
@@ -53,7 +66,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: deploy/repo.Dockerfile
+          file: deploy/repo.nonroot.Dockerfile
           push: true
           tags: ${{ steps.meta-nonroot.outputs.tags }}
           labels: ${{ steps.meta-nonroot.outputs.labels }}

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to GitHub container registry
         uses: docker/login-action@v2
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to GitHub container registry
         uses: docker/login-action@v2

--- a/deploy/repo.Dockerfile
+++ b/deploy/repo.Dockerfile
@@ -7,6 +7,12 @@ FROM python:3.10-slim-buster
 WORKDIR /root
 COPY . .
 
-RUN pip install --no-cache-dir --no-warn-script-location -e .
+# Install dependencies (including optional ones that make uvicorn faster)
+# Upgrade pip to the lastest version
+RUN pip --no-cache-dir install pip --upgrade && \
+    # Install optional depedencies that make uvicorn faster
+    pip --no-cache-dir install uvicorn uvloop httptools && \
+    # Install timetagger depedencies defined via setup.py
+    pip install --no-cache-dir --no-warn-script-location -e .
 
 CMD ["python", "-m", "timetagger"]

--- a/deploy/repo.Dockerfile
+++ b/deploy/repo.Dockerfile
@@ -4,24 +4,9 @@
 
 FROM python:3.10-slim-buster
 
-# Switch to unpriviliged user
-RUN groupadd -g 1000 timetagger && \
-    useradd -r -u 1000 -m -g timetagger timetagger && \
-    mkdir /opt/timetagger && \
-    chown timetagger:timetagger /opt/timetagger
+WORKDIR /root
+COPY . .
 
-USER 1000
-
-# Install dependencies (including optional ones that make uvicorn faster)
-RUN pip --no-cache-dir install --no-warn-script-location pip --upgrade && pip --no-cache-dir install --no-warn-script-location \
-    uvicorn uvloop httptools \
-    fastuaparser itemdb asgineer requests \
-    jinja2 markdown pscript \
-    pyjwt cryptography
-
-WORKDIR /opt/timetagger
-COPY . /opt/timetagger
-
-RUN pip install -e .
+RUN pip install --no-cache-dir --no-warn-script-location -e .
 
 CMD ["python", "-m", "timetagger"]

--- a/deploy/repo.Dockerfile
+++ b/deploy/repo.Dockerfile
@@ -4,15 +4,23 @@
 
 FROM python:3.10-slim-buster
 
+# Switch to unpriviliged user
+RUN groupadd -g 1000 timetagger && \
+    useradd -r -u 1000 -m -g timetagger timetagger && \
+    mkdir /opt/timetagger && \
+    chown timetagger:timetagger /opt/timetagger
+
+USER 1000
+
 # Install dependencies (including optional ones that make uvicorn faster)
-RUN pip --no-cache-dir install pip --upgrade && pip --no-cache-dir install \
+RUN pip --no-cache-dir install --no-warn-script-location pip --upgrade && pip --no-cache-dir install --no-warn-script-location \
     uvicorn uvloop httptools \
-    fastuaparser itemdb>=1.1.1 asgineer requests \
+    fastuaparser itemdb asgineer requests \
     jinja2 markdown pscript \
     pyjwt cryptography
 
-WORKDIR /root
-COPY . .
+WORKDIR /opt/timetagger
+COPY . /opt/timetagger
 
 RUN pip install -e .
 

--- a/deploy/repo.nonroot.Dockerfile
+++ b/deploy/repo.nonroot.Dockerfile
@@ -1,0 +1,21 @@
+# Dockerfile to build an image from the repo.
+# Note that the build context must be the root of the repo.
+# Used by CI to build the image that is pushed to ghcr.
+# Unpriviliged version that installs and runs as UID 1000.
+
+FROM python:3.10-slim-buster
+
+# Switch to unpriviliged user
+RUN groupadd -g 1000 timetagger && \
+    useradd -r -u 1000 -m -g timetagger timetagger && \
+    mkdir /opt/timetagger && \
+    chown timetagger:timetagger /opt/timetagger
+
+USER 1000
+
+WORKDIR /opt/timetagger
+COPY . /opt/timetagger
+
+RUN pip install --no-cache-dir --no-warn-script-location -e .
+
+CMD ["python", "-m", "timetagger"]

--- a/deploy/repo.nonroot.Dockerfile
+++ b/deploy/repo.nonroot.Dockerfile
@@ -5,17 +5,24 @@
 
 FROM python:3.10-slim-buster
 
-# Switch to unpriviliged user
+# Create unpriviliged user and group, including directory structure
 RUN groupadd -g 1000 timetagger && \
     useradd -r -u 1000 -m -g timetagger timetagger && \
     mkdir /opt/timetagger && \
     chown timetagger:timetagger /opt/timetagger
 
+# Switch to unpriviliged user
 USER 1000
 
 WORKDIR /opt/timetagger
 COPY . /opt/timetagger
 
-RUN pip install --no-cache-dir --no-warn-script-location -e .
+# Install dependencies (including optional ones that make uvicorn faster)
+# Upgrade pip to the lastest version
+RUN pip --no-cache-dir install pip --upgrade && \
+    # Install optional depedencies that make uvicorn faster
+    pip --no-cache-dir install uvicorn uvloop httptools && \
+    # Install timetagger depedencies defined via setup.py
+    pip install --no-cache-dir --no-warn-script-location -e .
 
 CMD ["python", "-m", "timetagger"]


### PR DESCRIPTION
Dear @almarklein, I just started to use your awesome `timetagger` app for my personal time tracking needs. Great project I really like it!

I noticed that the ghcr published images and also the other container variants make use of the `root` user with `uid` and `gid` of `0`.

In order to make container escapes harder and follow security best-practices I introduced an unprivileged service user named `timetagger` with `uid` and `gid` of `1000` to the `repo.Dockerfile`.

This might be considered as a breaking change as existing self hosted installations probably need to alter their persistent data in order to be able to use the unprivileged variant.

Before going forward with this change, maybe also on the other container variants, I wanted to get your feedback first if this contribution is something you are interested in before spending more time on it?

Changes included so far:
- switch to unprivileged service user named `timetagger` with `uid` and `gid` of `1000`
- moved application source from `/root` to `/opt/timetagger`
- `pip install` is know running as service user too and not as `root` anymore
- removed `itemdb` version constraint as older versions than `1.1.1` would not be installed by default

Looking forward to your feedback!