### PR TITLE
Add docker image for arm64

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -15,8 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
-
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Log in to GitHub container registry
         uses: docker/login-action@v2
         with:
@@ -26,7 +29,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v3
         with:
           images: ghcr.io/${{ github.repository }}
           tags: type=ref,event=tag
@@ -35,6 +38,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: deploy/repo.Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This PR improves CD action to build an arm64 Docker image that could be used on Raspberry PI (#257). I based it on the [offical Docker documentation](https://docs.docker.com/build/ci/github-actions/multi-platform/). The change was tested on my fork, where I was able to build an arm64 image (see https://github.com/maresmar/timetagger/pkgs/container/timetagger/97423218?tag=v0.0.2 and the [workflow log](https://github.com/maresmar/timetagger/actions/runs/5126767620/jobs/9221673889).

The arm64 image is running fine on my Raspberry Pi 3+ (with Raspbery OS 64bit, 2023-02-21).