### PR TITLE
Implement a read-only mode (for when the trial has expired)

### DIFF
--- a/timetagger/app/app.scss
+++ b/timetagger/app/app.scss
@@ -278,6 +278,12 @@ body.darkmode .dialog button.actionbutton.submit { background: $acc_clr; }
     .dialog button.actionbutton { margin-left: 1em; font-size: 100%; }
     .dialog button.actionbutton.submit { min-width: 7em; }
 }
+body.is_read_only button.actionbutton {
+    color: #aaa;
+    box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.2);
+    pointer-events: none; /* Prevent clicks */
+}
+body.is_read_only button.actionbutton:hover { box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.2); }
 
 .dialog .tag-suggestions-autocomp {
     position: absolute;

--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -215,7 +215,7 @@ class BaseDialog:
         self.maindiv = document.createElement("form")
         self.maindiv.addEventListener("keydown", self._on_key, 0)
         self._canvas.node.parentNode.appendChild(self.maindiv)
-        self.maindiv.className = "dialog"
+        self.maindiv.classList.add("dialog")
         self.maindiv.setAttribute("tabindex", -1)
 
     def _show_dialog(self):
@@ -530,7 +530,7 @@ class TimeSelectionDialog(BaseDialog):
             </div>
             <div style='margin-top:1em;'></div>
             <div style='display: flex;justify-content: flex-end;'>
-                <button type='button' class='actionbutton'>Done</button>
+                <button type='button'>Done</button>
             </div>
         """
 
@@ -1872,7 +1872,7 @@ class TagComboDialog(BaseDialog):
             clr = window.store.settings.get_color_for_tag(tag)
             el = document.createElement("button")
             el.setAttribute("type", "button")
-            el.classList.add("actionbutton")
+            el.style.marginRight = "3px"
             el.innerHTML = f"<b style='color:{clr};'>#</b>" + tag[1:]
             el.onclick = self._make_click_handler(tag, callback)
             button_div.appendChild(el)

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -2761,7 +2761,8 @@ class RecordsWidget(Widget):
                     if isrunning:
                         record.t1 = min(record.t1, self._canvas.now())
                         record.t2 = record.t1
-                    window.store.records.put(record)
+                    if not window.store.is_read_only:
+                        window.store.records.put(record)
                     if "up" in ev.type:
                         self._selected_record[1] = 0
                     self.update()


### PR DESCRIPTION
Previously, when the trial was expired, the app still worked, but changes were simply not pushed to the server. This was confusing, because users may not take notice of the sync icon showing an exclamation mark and just carry on. This PR allows the server the put the app in readonly mode so the dialogs prevent making changes, resolving the confusion.