### PR TITLE
Fix glitch in display of duration

### DIFF
--- a/tests/test_client_dt.py
+++ b/tests/test_client_dt.py
@@ -106,13 +106,17 @@ def test_duration_string():
     js4 = evaljs(js, f"duration_string(65, true)")
     js5 = evaljs(js, f"duration_string(7265, false)")
     js6 = evaljs(js, f"duration_string(7265, true)")
+    js7 = evaljs(js, f"duration_string(42, false)")
+    js8 = evaljs(js, f"duration_string(42, true)")
 
-    assert js1 == "0m"
+    assert js1 == "5s"
     assert js2 == "0m05s"
     assert js3 == "1m"
     assert js4 == "1m05s"
     assert js5 == "2h01m"
     assert js6 == "2h01m05s"
+    assert js7 == "42s"
+    assert js8 == "0m42s"
 
     js1 = evaljs(js, f"duration_string_colon(5, false)")
     js2 = evaljs(js, f"duration_string_colon(5, true)")

--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -3976,7 +3976,7 @@ class PomodoroDialog(BaseDialog):
         etime = self._state[1]
         left = max(0, etime - dt.now())
         if left:
-            return self._state[0] + ": " + dt.duration_string(left, True)[2:]
+            return self._state[0] + ": " + dt.duration_string(left, True)
         else:
             return None
 

--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -1740,7 +1740,7 @@ class RecordDialog(BaseDialog):
         if t2 is None:
             t2 = dt.now()
         for record in records:
-            record.t2 = max(record.t1 + 10, t2)
+            record.t2 = max(record.t1 + 2, t2)
             window.store.records.put(record)
 
     def submit(self):

--- a/timetagger/app/dt.py
+++ b/timetagger/app/dt.py
@@ -271,7 +271,9 @@ def duration_string_colon(t, show_secs=False):
     sign = "-" if t < 0 else ""
     t = abs(t)
     if show_secs:
-        return f"{sign}{t//3600:.0f}:{(t//60)%60:02.0f}:{t%60:02.0f}"
+        part1 = f"{sign}{t//3600:.0f}:{(t//60)%60:02.0f}"
+        part2 = f":{t%60:02.0f}"
+        return (part1, part2) if show_secs == 2 else (part1 + part2)
     else:
         m = Math.round(t / 60)
         return f"{sign}{m//60:.0f}:{m%60:02.0f}"
@@ -289,9 +291,12 @@ def duration_string(t, show_secs=False):
             m = (t // 60) % 60
             h = t // 3600
             if h:
-                return f"{sign}{h:.0f}h{m:02.0f}m{t%60:02.0f}s"
+                part1 = f"{sign}{h:.0f}h{m:02.0f}m"
+                part2 = f"{t%60:02.0f}s"
             else:
-                return f"{sign}{m:.0f}m{t%60:02.0f}s"
+                part1 = f"{sign}{m:.0f}m"
+                part2 = f"{t%60:02.0f}s"
+            return (part1, part2) if show_secs == 2 else (part1 + part2)
         else:
             m = Math.round(t / 60)
             h = m // 60

--- a/timetagger/app/dt.py
+++ b/timetagger/app/dt.py
@@ -276,6 +276,9 @@ def duration_string_colon(t, show_secs=False):
         return (part1, part2) if show_secs == 2 else (part1 + part2)
     else:
         m = Math.round(t / 60)
+        # Note how for anythinh below 30s is shown as 00:00. This is
+        # intentional because a single 00:00:28 would stand out quite
+        # oddly in a series of hh:mm entries.
         return f"{sign}{m//60:.0f}:{m%60:02.0f}"
 
 
@@ -302,8 +305,12 @@ def duration_string(t, show_secs=False):
             h = m // 60
             if h:
                 return f"{sign}{h:.0f}h{m%60:02.0f}m"
-            else:
+            elif m:
                 return f"{sign}{m%60:.0f}m"
+            else:
+                # Only show the secs (even if show_secs is False)
+                return f"{sign}{t:02.0f}s"
+
     else:
         return duration_string_colon(t, show_secs)
 

--- a/timetagger/app/dt.py
+++ b/timetagger/app/dt.py
@@ -305,11 +305,11 @@ def duration_string(t, show_secs=False):
             h = m // 60
             if h:
                 return f"{sign}{h:.0f}h{m%60:02.0f}m"
-            elif m:
+            elif t >= 60:
                 return f"{sign}{m%60:.0f}m"
             else:
                 # Only show the secs (even if show_secs is False)
-                return f"{sign}{t:02.0f}s"
+                return f"{sign}{t:.0f}s"
 
     else:
         return duration_string_colon(t, show_secs)

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -1454,12 +1454,12 @@ class TopWidget(Widget):
                 records = window.store.records.get_running_records()
                 if len(records) > 0:
                     record = records[0]
-                    record.t2 = max(record.t1 + 10, now)
+                    record.t2 = max(record.t1 + 2, now)
                     self._canvas.record_dialog.open("Stop", record, self.update)
             elif action == "record_stopall":
                 records = window.store.records.get_running_records()
                 for record in records:
-                    record.t2 = max(record.t1 + 10, now)
+                    record.t2 = max(record.t1 + 2, now)
                     window.store.records.put(record)
                 if window.simplesettings.get("pomodoro_enabled"):
                     self._canvas.pomodoro_dialog.stop()
@@ -2753,9 +2753,9 @@ class RecordsWidget(Widget):
                             record.t2 = record.t1 + dt
                     # Finish
                     if self._selected_record[1] == 1:
-                        record.t1 = min(record.t2 - 10, record.t1)
+                        record.t1 = min(record.t2 - 2, record.t1)
                     else:
-                        record.t2 = max(record.t1 + 10, record.t2)
+                        record.t2 = max(record.t1 + 2, record.t2)
                     if isrunning:
                         record.t1 = min(record.t1, self._canvas.now())
                         record.t2 = record.t1

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -2254,9 +2254,7 @@ class RecordsWidget(Widget):
             duration_sec = ""
         else:
             duration = now - record.t1
-            duration_text_full = dt.duration_string(duration, True)
-            duration_text = dt.duration_string(duration, False)
-            duration_sec = duration_text_full[len(duration_text) :]
+            duration_text, duration_sec = dt.duration_string(duration, 2)
         ctx.fillStyle = COLORS.record_text if tags_selected else faded_clr
         ctx.textAlign = "right"
         ctx.fillText(duration_text, x5 + 30, text_ypos)
@@ -3421,9 +3419,7 @@ class AnalyticsWidget(Widget):
 
         # Get duration text
         if is_running:
-            duration_text_full = dt.duration_string(bar.t, True)
-            duration_text = dt.duration_string(bar.t, False)
-            duration_sec = duration_text_full[len(duration_text) :]
+            duration_text, duration_sec = dt.duration_string(bar.t, 2)
         else:
             duration_text = dt.duration_string(bar.t, False)
             duration_sec = ""


### PR DESCRIPTION
Two glitches and one improvement actually:
* In the display of the time left on the current pomodoro work/break, the code assumed the "hh:mm:ss"  notation and simply stripped off the first two characters. But that fails for e.g. "4h12m01s".
* When not showing seconds, the minutes are rounded (1m28s becomes 1m, 1m32s becomes 2m). But there was some code in two places that took the duration string both with and without seconds and used the two to draw the seconds in a different color. But the effect was that 1m32s was then displayed as 2m32s. Oops.
* When the duration is less than a minute, the duration is expressed in seconds. So 42 seconds would be "42s" instead of "1m", and 12 seconds would be "12s" instead of "0m". Note that when using "hh:mm" notation (via the settings), it will still be "00:00".

Note that none of the above two glitches affected reporting or exports.