### PR TITLE
Fix sorting search results

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -2561,7 +2561,7 @@ class SearchDialog(BaseDialog):
                 # All checks passed
                 records.push([record.t1, record.key])
 
-        records.sort(key=lambda x: x[1])
+        records.sort(key=lambda x: -x[0])
         self._records = [x[1] for x in records]
         self._show_records()
         self._check_names()


### PR DESCRIPTION
Closes #383

The search result was sorted, but it took the wrong field, taking the key, which is a random string. In effect the search results were completely mixed in terms of time (though it was consistent each time).

This small PR makes the search result be sorted chronologically, latest records first.