### PR TITLE
Improvements to report grouping

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -2672,6 +2672,7 @@ class ReportDialog(BaseDialog):
                 <div>Grouping:</div> <select>
                                         <option value='none'>none</option>
                                         <option value='tagz'>tags</option>
+                                        <option value='ds'>description</option>
                                         <option value='date'>date</option>
                                         <option value='tagz/date'>tags / date</option>
                                         <option value='date/tagz'>date / tags</option>
@@ -2844,6 +2845,22 @@ class ReportDialog(BaseDialog):
                 group.records.push(record)
                 group.t += record.t2 - record.t1
             group_list = groups.values()
+
+        elif group_method == "ds":
+            groups = {}
+            for i in range(len(records)):
+                record = records[i]
+                tagz1 = window.store.records.tags_from_record(record).join(" ")
+                if tagz1 not in name_map:
+                    continue
+                ds = record.ds
+                if ds not in groups:
+                    groups[ds] = {"title": ds, "t": 0, "records": []}
+                group = groups[ds]
+                group.records.push(record)
+                group.t += record.t2 - record.t1
+            group_list = groups.values()
+            group_list.sort(key=lambda x: x.title.lower())
 
         elif group_method == "date":
             groups = {}

--- a/timetagger/app/utils.py
+++ b/timetagger/app/utils.py
@@ -622,6 +622,7 @@ class SimpleSettings:
             "width_mode": "auto",
             "pomodoro_enabled": False,
             "report_grouping": "date",
+            "report_groupperiod": "none",
             "report_hidesecondary": False,
             "report_hourdecimals": False,
             "report_showrecords": True,


### PR DESCRIPTION
Closes #304, closes #348.

This refactors the grouping mechanics in the report dialog. There are now two dropdown buttons. One to select the primary grouping, and one for the time period. You can now also group by description, and by different periods.

<img width="560" alt="image" src="https://github.com/almarklein/timetagger/assets/3015475/fa7e0309-8c15-404e-a2ad-6800c592e3b6">

<img width="553" alt="image" src="https://github.com/almarklein/timetagger/assets/3015475/0bd0d982-8fc9-406b-8710-36251978ecc3">
