### PR TITLE
Tweak when startup tips are shown

### DIFF
--- a/timetagger/app/dt.py
+++ b/timetagger/app/dt.py
@@ -65,6 +65,14 @@ def now():
         return time.time()
 
 
+_start_time = now()
+
+
+def time_since_app_loaded():
+    """Get the number of seconds since the app loaded."""
+    return now() - _start_time
+
+
 def to_time_int(t):
     """Get a time (in int seconds since epoch), given float/str input.
     String inputs can be:

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -1095,7 +1095,8 @@ class TopWidget(Widget):
         )
 
         if (
-            window.store.records.put_count < 10
+            dt.time_since_app_loaded() > 4
+            and window.store.records.put_count < 5
             and not self._canvas.guide_dialog.initialized
         ):
             # Help new users find the guide
@@ -1297,7 +1298,7 @@ class TopWidget(Widget):
             )
             x -= dx
 
-            if window.store.records.put_count == 0:
+            if dt.time_since_app_loaded() > 3 and window.store.records.put_count == 0:
                 # Help new users find the record button (can test this in the sandbox)
                 x_balloon = x + 0.5 * dx
                 ctx.strokeStyle = COLORS.acc_clr


### PR DESCRIPTION
When the app loads, it queries the records from memory and the server. It therefore has zero records for a brief period, which caused the newby-tips to be shown for a moment, which feels a bit glitchy. This fixes that. The tips appear somewhat later, which makes them stand out even better, I suppose!