### PR TITLE
Added 'Y' to select year view as shortcut

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -3690,6 +3690,7 @@ class SettingsDialog(BaseDialog):
             "D": "Select today",
             "W": "Select this week",
             "M": "Select this month",
+            "Y": "Select this year",
             "↑/PageUp": "Step back in time",
             "↓/PageDown": "Step forward in time",
             "→": "Zoom in",

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -1449,6 +1449,8 @@ class TopWidget(Widget):
             self._handle_button_press("nav_snap_now1W")
         elif e.key.lower() == "m":
             self._handle_button_press("nav_snap_now1M")
+        elif e.key.lower() == "y":
+            self._handle_button_press("nav_snap_now1Y")
         elif e.key.lower() == "t":
             self._handle_button_press("nav_menu")
         #


### PR DESCRIPTION
Hey @almarklein,

searching through the issues of timetagger I found #406.
As I wanted to familiarize myself with the codebase this looked like a quick win.

This PR adds Y/y as a shortcut to zoom the current view to the whole year.