### PR TITLE
Added 5 minute interval align for time select buttons

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -878,6 +878,18 @@ class StartStopEdit:
             hh, mm, ss = utils.timestr2tuple(self["ori_" + what])
         return hh, mm, ss
 
+    def _stepwise_delta(self, mm, delta):
+        if delta >= 0:
+            # delta is positiv, apply modulo with offset
+            return (delta - (mm%delta))
+        else:
+            # delta is negative
+            mm_new = -(mm%-(delta))
+            if mm_new == 0:
+                # we are already at stepsize, just return delta
+                return delta
+            return mm_new
+
     def render(self):
         now = dt.now()
 
@@ -919,6 +931,10 @@ class StartStopEdit:
             self.date2input.style.color = None
 
     def onchanged(self, action):
+
+        # step size used for time buttons
+        _stepsize = 5
+
         now = dt.now()
 
         # Get node
@@ -986,9 +1002,9 @@ class StartStopEdit:
             else:
                 hh, mm, ss = self._get_time("time1")
                 if option == "more":
-                    mm, ss = mm + 5, 0
+                    mm, ss = mm + self._stepwise_delta(mm, _stepsize), 0
                 elif option == "less":
-                    mm, ss = mm - 5, 0
+                    mm, ss = mm + self._stepwise_delta(mm, -(_stepsize)), 0
                 d1 = window.Date(year1, month1 - 1, day1, hh, mm, ss)
                 self.t1 = dt.to_time_int(d1)
                 if self.ori_t1 == self.ori_t2:
@@ -1008,9 +1024,9 @@ class StartStopEdit:
             else:
                 hh, mm, ss = self._get_time("time2")
                 if option == "more":
-                    mm, ss = mm + 5, 0
+                    mm, ss = mm + self._stepwise_delta(mm, _stepsize), 0
                 elif option == "less":
-                    mm, ss = mm - 5, 0
+                    mm, ss = mm + self._stepwise_delta(mm, -(_stepsize)), 0
                 d2 = window.Date(year2, month2 - 1, day2, hh, mm, ss)
                 self.t2 = dt.to_time_int(d2)
                 if self.ori_t1 == self.ori_t2:


### PR DESCRIPTION
Hi @almarklein,

I stumbled across #216 which is a behavior I could make use of as well.
This PR adds support for interval alignment during time select using the +/- buttons.
In this version fractions of the interval/step size (e.g. 42) will be align during the first button press to the respective step size (e.g. 45). Afterwards each step will align with the step size.

Let me know what you think about this change.