### PR TITLE
Fix hang and crispier look

### DIFF
--- a/timetagger/app/app.scss
+++ b/timetagger/app/app.scss
@@ -5,7 +5,6 @@ body.darkmode { background: $bg3; }
     position: absolute;
     top: 0; left: 0; bottom: 0; right: 0; width: 100%; height: 100vh;
     border: 0; margin: 0; padding: 0; outline: none;
-    box-sizing: border-box;
     box-shadow: 0 0 4px rgba(0, 0, 0, 0.4);
     border-radius: 2px;
     background: $sec2_clr;

--- a/timetagger/app/app.scss
+++ b/timetagger/app/app.scss
@@ -5,6 +5,7 @@ body.darkmode { background: $bg3; }
     position: absolute;
     top: 0; left: 0; bottom: 0; right: 0; width: 100%; height: 100vh;
     border: 0; margin: 0; padding: 0; outline: none;
+    box-sizing: border-box;
     box-shadow: 0 0 4px rgba(0, 0, 0, 0.4);
     border-radius: 2px;
     background: $sec2_clr;

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -239,7 +239,7 @@ class TimeTaggerCanvas(BaseCanvas):
 
         x0 = 0
         x1 = margin
-        x2 = x1 + records_width
+        x2 = x1 + max(0, records_width)
         x3 = x2 + margin2
         x4 = self.w - margin
         x5 = self.w  # noqa
@@ -251,7 +251,7 @@ class TimeTaggerCanvas(BaseCanvas):
 
         y0 = 0
         y1 = self.grid_round(140)
-        y3 = self.grid_round(self.h - 15)
+        y3 = self.grid_round(max(y1 + 40, self.h - 15))
 
         self.widgets["TopWidget"].rect = x0, y0, x5, y1
         self.widgets["RecordsWidget"].rect = x1, y1, x2, y3
@@ -598,7 +598,7 @@ class TimeRange:
         # Define ticks
         ticks = []
         minor_ticks = []
-        maxi = 2 * npixels / min_distance
+        maxi = min(2 * npixels / min_distance, 99)
         t = dt.floor(t1 - 0.1 * nsecs, delta)
         iter = -1
         while iter < maxi:  # just to be safe
@@ -613,7 +613,9 @@ class TimeRange:
                 t_new = dt.add(t, delta)
             # Minor ticks
             t_minor = dt.add(t, minor_delta)
-            while (t_new - t_minor) > 0:
+            iter_minor = -1
+            while iter_minor < 20 and (t_new - t_minor) > 0:
+                iter_minor += 1
                 pix_pos = (t_minor - t1) * npixels / nsecs
                 minor_ticks.push((pix_pos, t_minor))
                 t_minor_new = dt.add(t_minor, minor_delta)
@@ -635,7 +637,9 @@ class TimeRange:
                         # Add minor ticks at duplicate hour
                         d_minor = dt.add(t_new, minor_delta) - t_new
                         t_minor = tb + d_minor
-                        while t_minor < tc:
+                        iter_minor = -1
+                        while iter_minor < 20 and t_minor < tc:
+                            iter_minor += 1
                             pix_pos = (t_minor - t1) * npixels / nsecs + 3
                             minor_ticks.push((pix_pos, t_minor))
                             t_minor += d_minor
@@ -914,6 +918,10 @@ class TopWidget(Widget):
     def on_draw(self, ctx, menu_only=False):
         self._picker.clear()
         x1, y1, x2, y2 = self.rect
+
+        # Guard for small screen space during resize
+        if x2 - x1 < 50 or y2 - y1 < 20:
+            return
 
         y4 = y2  # noqa - bottom
         y2 = y1 + 60
@@ -1618,6 +1626,10 @@ class RecordsWidget(Widget):
     def on_draw(self, ctx):
         x1, y1, x2, y2 = self.rect
         self._picker.clear()
+
+        # Guard for small screen space during resize
+        if y2 - y1 < 20:
+            return
 
         # If too little space, only draw button to expand
         if x2 - x1 <= 50:
@@ -3000,6 +3012,11 @@ class AnalyticsWidget(Widget):
 
     def on_draw(self, ctx):
         x1, y1, x2, y2 = self.rect
+
+        # Guard for small screen space during resize
+        if y2 - y1 < 20:
+            return
+
         self._picker.clear()
 
         # If too little space, only draw button to expand

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -1156,18 +1156,18 @@ class TopWidget(Widget):
 
     def _draw_sync_feedback(self, ctx, x1, y1, radius):
         self._sync_feedback_xy = x1, y1, radius
-        return self._draw_sync_feedback_work()
+        return self._draw_sync_feedback_work(ctx)
 
     def _draw_sync_feedback_callback(self):
-        self._draw_sync_feedback_work(False)
+        ctx = self._canvas.node.getContext("2d")
+        self._draw_sync_feedback_work(ctx, False)
 
-    def _draw_sync_feedback_work(self, register=True):
+    def _draw_sync_feedback_work(self, ctx, register=True):
         PSCRIPT_OVERLOAD = False  # noqa
 
         if window.document.hidden:
             return
 
-        ctx = self._canvas.node.getContext("2d")
         x, y, radius = self._sync_feedback_xy
 
         state = window.store.state

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -3017,6 +3017,8 @@ class AnalyticsWidget(Widget):
         if y2 - y1 < 20:
             return
 
+        # return self._draw_test_grid()
+
         self._picker.clear()
 
         # If too little space, only draw button to expand
@@ -3075,6 +3077,23 @@ class AnalyticsWidget(Widget):
             # ctx.font = (FONT.size * 0.9) + "px " + FONT.default
             # ctx.fillStyle = COLORS.prim2_clr
             # ctx.fillText(self._help_text, x2 - 10, 90)
+
+    def _draw_test_grid(self, ctx):
+        x1, y1, x2, y2 = self.rect
+
+        x1, x2, x3 = int(x1), int((x1 + x2) / 2), int(x2)
+        y1, y2, y3 = int(y1), int((y1 + y2) / 2), int(y2)
+
+        ctx.strokeStyle = "#000"
+        ctx.lineWidth = 2
+        for i in range((x2 - x1) / 4):
+            ctx.moveTo(x1 + i * 4, y1)
+            ctx.lineTo(x1 + i * 4, y3)
+        ctx.stroke()
+        for i in range((y2 - y1) / 4):
+            ctx.moveTo(x1, y2 + i * 4)
+            ctx.lineTo(x3, y2 + i * 4)
+        ctx.stroke()
 
     def _draw_stats(self, ctx, x1, y1, x2, y2):
         PSCRIPT_OVERLOAD = False  # noqa

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -908,7 +908,11 @@ class TopWidget(Widget):
         self._button_pressed = None
         self._current_scale = {}
         self._sync_feedback_xy = 0, 0, 0
-        window.setInterval(self._draw_sync_feedback_callback, 100)
+
+        # Periodically draw the sync feedback icon. Make sure to do it via requestAnimationFrame
+        window.setInterval(
+            window.requestAnimationFrame, 100, self._draw_sync_feedback_callback
+        )
 
         # For navigation with keys. Listen to canvas events, and window events (in
         # case canvas does not have focus), but don't listen for events from dialogs.

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -58,7 +58,6 @@ def set_width_mode():
     entries = []
     add = lambda x: entries.push(x)
     content_div.classList.forEach(add)
-    print(entries)
     for entry in entries:
         if "width-" in entry:
             content_div.classList.remove(entry)

--- a/timetagger/app/utils.py
+++ b/timetagger/app/utils.py
@@ -839,15 +839,12 @@ class BaseCanvas:
             entry.devicePixelContentBoxSize[0].inlineSize,
             entry.devicePixelContentBoxSize[0].blockSize,
         ]
-        self._resize_info = psize
-        self.update(False)
+        self._apply_new_size(psize)
+        self._draw()
 
-    def _apply_new_size(self):
+    def _apply_new_size(self, psize):
         # This is called JIT right before a draw, when a resize has happened
 
-        # Get size info and reset the flag
-        psize = self._resize_info
-        self._resize_info = None
         # Get and store pixel ratio
         self.pixel_ratio = ratio = get_pixel_ratio()
         # Use that to obtain the real number of logical pixels
@@ -893,10 +890,6 @@ class BaseCanvas:
 
         # Reset flag
         self._pending_draw = False
-
-        # Need to resize?
-        if self._resize_info:
-            self._apply_new_size()
 
         # Is the element even visible
         if self.node.style.display == "none":


### PR DESCRIPTION
The app would sometimes hang, and it looks like it is possible to reproduce the hanging by resizing the window. This takes a couple of measures to prevent the hanging due to negative sizes, and also adds some guards to while loops so they always exit.

Also looked into a better way to determine the physical canvas size, so it's laid exactly ontop of the physical pixels (when possible).