### PR TITLE
Fix overview scrolling on mobile

### DIFF
--- a/timetagger/app/app.scss
+++ b/timetagger/app/app.scss
@@ -3,7 +3,7 @@ body.darkmode { background: $bg3; }
 
 #canvas {
     position: absolute;
-    top: 0; left: 0; bottom: 0; right: 0; width: 100%; height: 100%;
+    top: 0; left: 0; width: 100%; height: 100%;
     border: 0; margin: 0; padding: 0; outline: none;
     box-shadow: 0 0 4px rgba(0, 0, 0, 0.4);
     border-radius: 2px;

--- a/timetagger/app/app.scss
+++ b/timetagger/app/app.scss
@@ -1,6 +1,8 @@
 body { background: $bg1; }
 body.darkmode { background: $bg3; }
 
+main div.content { padding: 0; }
+
 #canvas {
     position: absolute;
     top: 0; left: 0; width: 100%; height: 100%;

--- a/timetagger/app/app.scss
+++ b/timetagger/app/app.scss
@@ -3,7 +3,7 @@ body.darkmode { background: $bg3; }
 
 #canvas {
     position: absolute;
-    top: 0; left: 0; bottom: 0; right: 0; width: 100%; height: 100vh;
+    top: 0; left: 0; bottom: 0; right: 0; width: 100%; height: 100%;
     border: 0; margin: 0; padding: 0; outline: none;
     box-shadow: 0 0 4px rgba(0, 0, 0, 0.4);
     border-radius: 2px;

--- a/timetagger/app/app.scss
+++ b/timetagger/app/app.scss
@@ -1,7 +1,7 @@
 body { background: $bg1; }
 body.darkmode { background: $bg3; }
 
-main div.content { padding: 0; }
+main div.content { padding: 0; }  /* prevent empty space at bottom on iPhone */
 
 #canvas {
     position: absolute;

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -3494,7 +3494,7 @@ class AnalyticsWidget(Widget):
         t1, t2 = self._canvas.range.get_range()
         x1, x2 = bar.x1, bar.x2
         y1, y2 = bar.y1, bar.y2
-        npixels = min(y2 - y1, self._npixels_each)
+        npixels = Math.round(min(y2 - y1, self._npixels_each))
 
         # Get whether the current tag combi corresponds to the currently running record.
         # The clock only ticks per second if now is within range, so we don't show seconds unless we can.

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -3197,9 +3197,10 @@ class AnalyticsWidget(Widget):
         y_bottom = y2 - 8
         avail_height2 = y_bottom - y_top
 
-        # From that we can derive how many bars we can show, and the max scroll offset
+        # From that we can derive how many bars we can show, and the max scroll offset.
+        # The extra 15 pixels is to help when a phone shows the navbar *over* the app.
         n_bars = int(avail_height2 / self._npixels_each)
-        max_scroll_offset = max(0, (len(bars) - n_bars) * self._npixels_each)
+        max_scroll_offset = max(0, (len(bars) - n_bars) * self._npixels_each + 15)
         self._target_scroll_offset = min(max_scroll_offset, self._target_scroll_offset)
         self._scroll_offset = self._slowly_update_value(
             self._scroll_offset, self._target_scroll_offset

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -3198,9 +3198,8 @@ class AnalyticsWidget(Widget):
         avail_height2 = y_bottom - y_top
 
         # From that we can derive how many bars we can show, and the max scroll offset.
-        # The extra 15 pixels is to help when a phone shows the navbar *over* the app.
         n_bars = int(avail_height2 / self._npixels_each)
-        max_scroll_offset = max(0, (len(bars) - n_bars) * self._npixels_each + 15)
+        max_scroll_offset = max(0, (len(bars) - n_bars) * self._npixels_each)
         self._target_scroll_offset = min(max_scroll_offset, self._target_scroll_offset)
         self._scroll_offset = self._slowly_update_value(
             self._scroll_offset, self._target_scroll_offset


### PR DESCRIPTION
Closes #425 

The buttons now respond to a click instead of down, and the overview can be scrolled by dragging. ~Also allows to scroll the overview up a bit more, in case the bottom of the app is obscured by a home bar.~ Fixed that the app takes up the full space, without having a bottom margin on iPhone or the bottom part of the app hidden by the Android navigation bar.

This also fixes #194 again, undoing the change in #198 where `100vh` was used instead of `100%`. The trick was to removing the padding of the parent element. [This post](https://stackoverflow.com/a/76979555/2271927) helped me find the solution.