### PR TITLE
Report sums rounded durations

### DIFF
--- a/timetagger/app/utils.py
+++ b/timetagger/app/utils.py
@@ -616,7 +616,7 @@ class SimpleSettings:
             "report_grouping": "date",
             "report_groupperiod": "none",
             "report_hidesecondary": False,
-            "report_hourdecimals": False,
+            "report_format": "hm",
             "report_showrecords": True,
         }
         self._synced_keys = {


### PR DESCRIPTION
Closes #408.

* [x] The report dialog now has multiple formats, including second-accuracy 1:21:32, as well as whole hours, and 1, 2, and 3 decimals.
* [x] The durations of each record rounded according to the format.
* [x] The totals are obtained by summing the rounded durations.

This way, the shown (rounded) numbers do actually add up to the totals (previously the summing was done on second-precision durations, leading to round-off errors, see #408).

----

![image](https://github.com/almarklein/timetagger/assets/3015475/5b92270d-b048-48b5-ba7c-19214626ece0)
