### PR TITLE
Add viewport metadata to /cred

### DIFF
--- a/timetagger/common/cred.html
+++ b/timetagger/common/cred.html
@@ -3,8 +3,9 @@
 
     <head>
         <meta charset="utf-8">
-        <title>Generate credentials</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="description" content="Generate username:password with BCrypt hashing.">
+        <title>Generate credentials</title>
 
         <style>
 


### PR DESCRIPTION
Not a big deal, but Google Search Console was complaining about this info missing. 