### PR TITLE
add multi-user support

### DIFF
--- a/timetagger/_config.py
+++ b/timetagger/_config.py
@@ -47,6 +47,7 @@ class Config:
         ("datadir", str, "~/_timetagger"),
         ("log_level", str, "info"),
         ("credentials", str, ""),
+        ("multiuserdb", to_bool, False),
         ("proxy_auth_enabled", to_bool, False),
         ("proxy_auth_trusted", str, "127.0.0.1"),
         ("proxy_auth_header", str, "X-Remote-User"),

--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -1743,8 +1743,10 @@ class RecordDialog(BaseDialog):
         # Show info about current tags in description
         tags, parts = utils.get_tags_and_parts_from_string(self._ds_input.value)
         tags_html = "Tags:&nbsp; &nbsp;"
-        if len(tags) == 0:
-            tags = ["#untagged"]
+        #if len(tags) == 0:
+        #    tags = ["#untagged"]
+        username = window.store.get_auth().username
+        utils.add_user_tag(tags, username)
         tags_list = []
         for tag in tags:
             clr = window.store.settings.get_color_for_tag(tag)
@@ -1816,6 +1818,8 @@ class RecordDialog(BaseDialog):
             return self.close()
         # Set record.ds
         _, parts = utils.get_tags_and_parts_from_string(to_str(self._ds_input.value))
+        username = window.store.get_auth().username
+        utils.add_user_tag(parts, username, True)
         self._record.ds = parts.join("")
         if not self._record.ds:
             self._record.pop("ds", None)

--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -3837,6 +3837,10 @@ class SettingsDialog(BaseDialog):
             <label>
                 <input type='checkbox' checked='true'></input>
                 Show elapsed time below start-button</label>
+            <br />
+            <label>
+                <input type='checkbox' checked='false'></input>
+                Show all users</label>
 
             <hr style='margin-top: 1em;' />
 
@@ -3882,6 +3886,8 @@ class SettingsDialog(BaseDialog):
             self._repr_form,
             _,  # Misc header
             self._stopwatch_label,
+            _,  # br
+            self._all_users_label,
             _,  # hr
             _,  # Section: per device
             _,  # Appearance header
@@ -3933,6 +3939,13 @@ class SettingsDialog(BaseDialog):
         self._stopwatch_check = self._stopwatch_label.children[0]
         self._stopwatch_check.checked = show_stopwatch
         self._stopwatch_check.onchange = self._on_stopwatch_check
+
+        # All users
+        show_all_users = window.simplesettings.get("show_all_users")
+        console.log(f"show_all_users: {show_all_users}")
+        self._all_users_check = self._all_users_label.children[0]
+        self._all_users_check.checked = show_all_users
+        self._all_users_check.onchange = self._on_all_users_check
 
         # Device settings
 
@@ -4001,6 +4014,13 @@ class SettingsDialog(BaseDialog):
     def _on_stopwatch_check(self):
         show_stopwatch = bool(self._stopwatch_check.checked)
         window.simplesettings.set("show_stopwatch", show_stopwatch)
+
+    def _on_all_users_check(self):
+        show_all_users = bool(self._all_users_check.checked)
+        window.simplesettings.set("show_all_users", show_all_users)
+        # empty local record store. how?
+        #window.stores.ConnectedDataStore()._clear_cache()
+        #window.stores.ConnectedDataStore().reset()
 
 
 class GuideDialog(BaseDialog):

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -69,7 +69,7 @@ def set_width_mode():
 # Also see e.g. https://www.canva.com/colors/color-wheel/
 def set_colors():
     # Dark vs light mode
-    mode = mode = window.simplesettings.get("darkmode")
+    mode = window.simplesettings.get("darkmode")
     if mode == 1:
         light_mode = True
     elif mode == 2:

--- a/timetagger/app/stores.py
+++ b/timetagger/app/stores.py
@@ -130,8 +130,8 @@ _min_heap_bin_size = 2**17  # about 1.5 day
 
 # ----- COMMON PART (don't change this comment)
 
-RECORD_SPEC = dict(key=to_str, mt=to_int, t1=to_int, t2=to_int, ds=to_str)
-RECORD_REQ = ["key", "mt", "t1", "t2"]
+RECORD_SPEC = dict(key=to_str, mt=to_int, t1=to_int, t2=to_int, ds=to_str, user=to_str)
+RECORD_REQ = ["key", "mt", "t1", "t2", "user"]
 
 SETTING_SPEC = dict(key=to_str, mt=to_int, value=to_jsonable)
 SETTING_REQ = ["key", "mt", "value"]
@@ -389,6 +389,7 @@ class RecordStore(BaseStore):
             t1=dt.to_time_int(t1),
             t2=dt.to_time_int(t2),
             ds=to_str(ds),
+            user=self._datastore._auth.username,
         )
 
     def tags_from_record(self, record):

--- a/timetagger/app/stores.py
+++ b/timetagger/app/stores.py
@@ -133,8 +133,8 @@ _min_heap_bin_size = 2**17  # about 1.5 day
 RECORD_SPEC = dict(key=to_str, mt=to_int, t1=to_int, t2=to_int, ds=to_str, user=to_str)
 RECORD_REQ = ["key", "mt", "t1", "t2", "user"]
 
-SETTING_SPEC = dict(key=to_str, mt=to_int, value=to_jsonable)
-SETTING_REQ = ["key", "mt", "value"]
+SETTING_SPEC = dict(idx=to_str, key=to_str, mt=to_int, value=to_jsonable, user=to_str)
+SETTING_REQ = ["idx", "key", "mt", "value", "user"]
 
 STR_MAX = 256
 JSON_MAX = 8192
@@ -303,9 +303,13 @@ class SettingsStore(BaseStore):
         self._datastore = datastore  # This object will handle sync and storage
         self._items = {}  # key -> setting
 
+    def to_idx(self, key, username):
+        return f"#user/{username}#{key}"
+
     def create(self, key, value):
         """Create a new setting from a key and value. Does not put it in the store."""
-        return dict(key=to_str(key), st=0, mt=int(dt.now()), value=to_jsonable(value))
+        username = self._datastore._auth.username
+        return dict(idx=self.to_idx(key, username), key=to_str(key), st=0, mt=int(dt.now()), value=to_jsonable(value), user=username)
 
     def _drop(self, key):
         # Called by datastore to discard items that were not accepted by the server

--- a/timetagger/app/utils.py
+++ b/timetagger/app/utils.py
@@ -224,6 +224,19 @@ def get_tags_and_parts_from_string(s="", sorted=True):
         tags.sort()
     return tags, parts
 
+def has_user_tag(tags):
+    for tag in tags:
+        if tag.startswith("#user/"):
+            return True
+    return False
+
+def add_user_tag(tags, username, parts=False):
+    if username is None:
+        return
+    if not has_user_tag(tags):
+        if parts:
+            tags.append(" ")
+        tags.append(f"#user/{username}")
 
 def get_better_tag_order_from_stats(
     stats, selected_tags, remove_selected, priorities=None
@@ -602,7 +615,7 @@ class SimpleSettings:
     Key-value pairs are stored in a cache for fast getters.
     The actual storage can be:
     * None / session only: unknown keys are not stored across sessions.
-    * Local storage: a predefined set of keys are stored in local storaged,
+    * Local storage: a predefined set of keys are stored in local storage,
       which means that they are device-specific.
     * Synced: synced to the server using the settings store.
     """

--- a/timetagger/app/utils.py
+++ b/timetagger/app/utils.py
@@ -639,6 +639,7 @@ class SimpleSettings:
             "today_snap_offset": "",
             "today_end_offset": "",
             "show_stopwatch": True,
+            "show_all_users": False,
         }
         # The data store for synced source
         self._store = None

--- a/timetagger/app/utils.py
+++ b/timetagger/app/utils.py
@@ -602,7 +602,7 @@ class SimpleSettings:
     Key-value pairs are stored in a cache for fast getters.
     The actual storage can be:
     * None / session only: unknown keys are not stored across sessions.
-    * Local storagee: a prefefined set of keys are stored in local storaged,
+    * Local storage: a predefined set of keys are stored in local storaged,
       which means that they are device-specific.
     * Synced: synced to the server using the settings store.
     """

--- a/timetagger/server/_utils.py
+++ b/timetagger/server/_utils.py
@@ -36,6 +36,9 @@ def user2filename(username):
     # agressively create a clean representation (for recognizability)
     # and a base64 encoded string (so that we can reverse this process).
 
+    if config.multiuserdb:
+        return os.path.join(ROOT_USER_DIR, "multiuser.db")
+
     clean = "".join((c if c in ok_chars else "-") for c in username)
     encoded = urlsafe_b64encode(username.encode()).decode()
     fname = clean + "~" + encoded + ".db"


### PR DESCRIPTION
Support for teams have long been discussed (https://github.com/almarklein/timetagger/issues/142).
While I know some persons using timetagger as individuals, we would like to use it in our team, allowing also to see the times of others users.
This PR extends timetagger for multiple user use, at least in a rudimentary way.

Design:
* Handle users by automatically given tags in the form of `#user/<USERNAME>`.
* Store all records in a single database. As this changes existing behavior, only do so, if `TIMETAGGER_MULTIUSERDB=True`.
* Extend the database tables by the column "user".
* Extend the API to either return the records of the current user or for all users.

In Settings, a user can switch between seeing only his personal records or the records for all users ("Show all users").

Limitations:
* Currently, after turning off "Show all users" timetagger still shows all records. After relogin, only the personal records are shown.

Next steps:
I like to discuss, if this feature could get integrated into timetagger. If yes, what changes are required? Hints how to get around the current glitches are welcome.