### PR TITLE
Fixes iOS zoom issue

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -688,7 +688,7 @@ class StartStopEdit:
             <span></span>
         <span><i class='fas' style='color:#999; vertical-align:middle;'>\uf2f2</i></span>
             <span></span>
-            <input type='text' style='flex: 1; min-width: 50px; font-size: 80%' />
+            <input type='text' style='flex: 1; min-width: 50px; font-size: 16px' />
             <span></span>
         </div>
         """

--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -671,17 +671,17 @@ class StartStopEdit:
         </div>
         <div>
         <span><i class='fas' style='color:#999; vertical-align:middle;'>\uf144</i></span>
-            <input type='date' step='1'  style='font-size: 70%;' />
+            <input type='date' step='1'  style='font-size: 16px;' />
             <span style='display: flex;'>
-                <input type='text' style='flex:1; min-width: 50px; font-size: 80%;' />
+                <input type='text' style='flex:1; min-width: 50px; font-size: 16px;' />
                 <button type='button' style='width:2em; margin-left:-1px;'>+</button>
                 <button type='button' style='width:2em; margin-left:-1px;'>-</button>
                 </span>
             <span></span>
         <span><i class='fas' style='color:#999; vertical-align:middle;'>\uf28d</i></span>
-            <input type='date' step='1' style='font-size: 70%;' />
+            <input type='date' step='1' style='font-size: 16px;' />
             <span style='display: flex;'>
-                <input type='text' style='flex:1; min-width: 50px; font-size: 80%;' />
+                <input type='text' style='flex:1; min-width: 50px; font-size: 16px;' />
                 <button type='button' style='width:2em; margin-left:-1px;'>+</button>
                 <button type='button' style='width:2em; margin-left:-1px;'>-</button>
                 </span>


### PR DESCRIPTION
On iOS there is a common feature on all browsers where inputs with text under a certain size cause the view to zoom in to compensate. On a Progressive Web App this zoom cannot be reverted, requiring the app to be re-opened.
This pull request simply sets the inputs I found to have relative sizes to fixed 16px size to prevent the issue from happening.

Demonstration of the issue:
https://github.com/almarklein/timetagger/assets/72520178/48c91ccb-d626-4b03-9f1a-8494e470de5c

