### PR TITLE
Pass an import string rather than a function reference to enable multi-worker and reload support.

### DIFF
--- a/timetagger/__main__.py
+++ b/timetagger/__main__.py
@@ -243,4 +243,4 @@ TRUSTED_PROXIES = load_trusted_proxies()
 
 
 if __name__ == "__main__":
-    asgineer.run(main_handler, "uvicorn", config.bind, log_level="warning")
+    asgineer.run("timetagger.__main__:main_handler", "uvicorn", config.bind, log_level="warning")


### PR DESCRIPTION
The `uvicorn` docs [say](https://www.uvicorn.org/deployment/):

> Note that the application instance itself can be passed instead of the app import string.
>
>     uvicorn.run(app, host="127.0.0.1", port=5000, log_level="info")
>
> However, this style only works if you are not using multiprocessing (workers=NUM) or reloading (reload=True), so we recommend using the import string style.

Indeed, that seems to be true! This one-line change is enough, for example, to enable multi-worker support:

```bash
$ WEB_CONCURRENCY=4 .venv/bin/python3 -m timetagger --bind=localhost:5555

[INFO 2024-03-11 21:01:34] Collected 14 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/common/.
[INFO 2024-03-11 21:01:35] Compiled pscript from dialogs.py
[INFO 2024-03-11 21:01:35] Compiled pscript from dt.py
[INFO 2024-03-11 21:01:35] Compiled pscript from front.py
[INFO 2024-03-11 21:01:35] Compiled pscript from stores.py
[INFO 2024-03-11 21:01:35] Compiled pscript from tools.py
[INFO 2024-03-11 21:01:35] Compiled pscript from utils.py
[INFO 2024-03-11 21:01:35] Collected 13 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/app/.
[INFO 2024-03-11 21:01:35] Collected 26 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/images/.
[INFO 2024-03-11 21:01:35] Collected 4 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/pages/.
[INFO 2024-03-11 21:01:35] Collected 14 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/common/.
[INFO 2024-03-11 21:01:35] Collected 14 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/common/.
[INFO 2024-03-11 21:01:35] Collected 14 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/common/.
[INFO 2024-03-11 21:01:35] Collected 14 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/common/.
[INFO 2024-03-11 21:01:35] Compiled pscript from dialogs.py
[INFO 2024-03-11 21:01:35] Compiled pscript from dialogs.py
[INFO 2024-03-11 21:01:35] Compiled pscript from dialogs.py
[INFO 2024-03-11 21:01:35] Compiled pscript from dialogs.py
[INFO 2024-03-11 21:01:35] Compiled pscript from dt.py
[INFO 2024-03-11 21:01:35] Compiled pscript from dt.py
[INFO 2024-03-11 21:01:35] Compiled pscript from dt.py
[INFO 2024-03-11 21:01:35] Compiled pscript from dt.py
[INFO 2024-03-11 21:01:35] Compiled pscript from front.py
[INFO 2024-03-11 21:01:35] Compiled pscript from front.py
[INFO 2024-03-11 21:01:35] Compiled pscript from front.py
[INFO 2024-03-11 21:01:35] Compiled pscript from front.py
[INFO 2024-03-11 21:01:35] Compiled pscript from stores.py
[INFO 2024-03-11 21:01:35] Compiled pscript from tools.py
[INFO 2024-03-11 21:01:35] Compiled pscript from stores.py
[INFO 2024-03-11 21:01:35] Compiled pscript from stores.py
[INFO 2024-03-11 21:01:35] Compiled pscript from stores.py
[INFO 2024-03-11 21:01:35] Compiled pscript from tools.py
[INFO 2024-03-11 21:01:35] Compiled pscript from tools.py
[INFO 2024-03-11 21:01:35] Compiled pscript from tools.py
[INFO 2024-03-11 21:01:35] Compiled pscript from utils.py
[INFO 2024-03-11 21:01:35] Collected 13 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/app/.
[INFO 2024-03-11 21:01:35] Collected 26 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/images/.
[INFO 2024-03-11 21:01:35] Collected 4 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/pages/.
[INFO 2024-03-11 21:01:35] Compiled pscript from utils.py
[INFO 2024-03-11 21:01:35] Collected 13 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/app/.
[INFO 2024-03-11 21:01:35] Compiled pscript from utils.py
[INFO 2024-03-11 21:01:35] Collected 13 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/app/.
[INFO 2024-03-11 21:01:35] Compiled pscript from utils.py
[INFO 2024-03-11 21:01:35] Collected 13 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/app/.
[INFO 2024-03-11 21:01:35] Collected 26 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/images/.
[INFO 2024-03-11 21:01:35] Collected 26 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/images/.
[INFO 2024-03-11 21:01:35] Collected 26 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/images/.
[INFO 2024-03-11 21:01:35] Collected 4 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/pages/.
[INFO 2024-03-11 21:01:35] Collected 4 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/pages/.
[INFO 2024-03-11 21:01:35] Collected 4 assets from /Users/.../timetagger/.venv/lib/python3.9/site-packages/timetagger/pages/.
[INFO 2024-03-11 21:01:36] Server is starting up
[INFO 2024-03-11 21:01:36] Server is starting up
[INFO 2024-03-11 21:01:36] Server is starting up
[INFO 2024-03-11 21:01:36] Server is starting up
```

(`WEB_CONCURRENCY` is documented on that same page.)

Of course, this assumes that the server isn't holding some key state only in memory...