### PR TITLE
Use standalone display for better user experience on Android.

### DIFF
--- a/timetagger/app/timetagger_manifest.json
+++ b/timetagger/app/timetagger_manifest.json
@@ -6,7 +6,7 @@
     "lang": "en-US",
     "start_url": "./",
     "scope": "./",
-    "display": "fullscreen",
+    "display": "standalone",
     "theme_color": "#F4F4F4",
     "background_color": "#E6E7E5",
     "icons": [


### PR DESCRIPTION
Without this on my Android phone separate webapp had lack of controls in the bottom of screen, so it wes difficult to close it or switch to another application.

With standalone setting it works just as ordinal Android application.