### PR TITLE
Bump to Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,7 @@ jobs:
         run: |
             python -m pip install --upgrade pip
             pip install -U -r requirements.txt
-            pip install pytest requests
-            python setup.py install
+            pip install pytest requests setuptools .
             rm -rf ./timetagger ./build ./egg-info
       - name: Test with pytest
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Linux py37
-            os: ubuntu-latest
-            pyversion: '3.7'
-          - name: Linux py38
-            os: ubuntu-latest
-            pyversion: '3.8'
           - name: Linux py39
             os: ubuntu-latest
             pyversion: '3.9'
@@ -51,15 +45,21 @@ jobs:
           - name: Linux py311
             os: ubuntu-latest
             pyversion: '3.11'
+          - name: Linux py312
+            os: ubuntu-latest
+            pyversion: '3.12'
+          - name: Linux py313
+            os: ubuntu-latest
+            pyversion: '3.13'
           - name: Linux pypy3
             os: ubuntu-latest
             pyversion: 'pypy3.9'
-          - name: Windows py39
+          - name: Windows py313
             os: windows-latest
-            pyversion: '3.9'
-          - name: MacOS py39
+            pyversion: '3.13'
+          - name: MacOS py313
             os: macos-latest
-            pyversion: '3.9'
+            pyversion: '3.13'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.pyversion }}

--- a/deploy/pip.Dockerfile
+++ b/deploy/pip.Dockerfile
@@ -11,7 +11,7 @@
 # mypaas.maxmem = 256m
 # mypaas.env = TIMETAGGER_CREDENTIALS
 
-FROM python:3.10-slim-buster
+FROM python:3.13-slim-bookworm
 
 # Install dependencies (including optional ones that make uvicorn faster)
 RUN pip --no-cache-dir install pip --upgrade && pip --no-cache-dir install \

--- a/deploy/repo.Dockerfile
+++ b/deploy/repo.Dockerfile
@@ -2,7 +2,7 @@
 # Note that the build context must be the root of the repo.
 # Used by CI to build the image that is pushed to ghcr.
 
-FROM python:3.10-slim-buster
+FROM python:3.13-slim-bookworm
 
 WORKDIR /root
 COPY . .

--- a/deploy/repo.nonroot.Dockerfile
+++ b/deploy/repo.nonroot.Dockerfile
@@ -3,7 +3,7 @@
 # Used by CI to build the image that is pushed to ghcr.
 # Unpriviliged version that installs and runs as UID 1000.
 
-FROM python:3.10-slim-buster
+FROM python:3.13-slim-bookworm
 
 # Create unpriviliged user and group, including directory structure
 RUN groupadd -g 1000 timetagger && \

--- a/timetagger/__main__.py
+++ b/timetagger/__main__.py
@@ -23,7 +23,7 @@ import sys
 import json
 import logging
 from base64 import b64decode
-from pkg_resources import resource_filename
+from importlib import resources
 
 import bcrypt
 import asgineer
@@ -55,10 +55,10 @@ if __name__ == "__main__" and len(sys.argv) >= 2:
 logger = logging.getLogger("asgineer")
 
 # Get sets of assets provided by TimeTagger
-common_assets = create_assets_from_dir(resource_filename("timetagger.common", "."))
-apponly_assets = create_assets_from_dir(resource_filename("timetagger.app", "."))
-image_assets = create_assets_from_dir(resource_filename("timetagger.images", "."))
-page_assets = create_assets_from_dir(resource_filename("timetagger.pages", "."))
+common_assets = create_assets_from_dir(resources.files("timetagger.common") / ".")
+apponly_assets = create_assets_from_dir(resources.files("timetagger.app") / ".")
+image_assets = create_assets_from_dir(resources.files("timetagger.images") / ".")
+page_assets = create_assets_from_dir(resources.files("timetagger.pages") / ".")
 
 # Combine into two groups. You could add/replace assets here.
 app_assets = dict(**common_assets, **image_assets, **apponly_assets)

--- a/timetagger/server/_assets.py
+++ b/timetagger/server/_assets.py
@@ -7,7 +7,7 @@ import os
 import re
 import hashlib
 import logging
-import pkg_resources
+from importlib import resources
 
 import jinja2
 import pscript
@@ -29,14 +29,14 @@ AUDIO_EXTS = ".wav", ".mp3", ".ogg"
 re_fas = re.compile(r"\>(\\uf[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])\<")
 
 default_template = (
-    open(pkg_resources.resource_filename("timetagger.common", "_template.html"), "rb")
+    open(resources.files("timetagger.common") / "_template.html", "rb")
     .read()
     .decode()
 )
 
 
 def _get_base_style():
-    fname = pkg_resources.resource_filename("timetagger.common", "_style_embed.scss")
+    fname = resources.files("timetagger.common") / "_style_embed.scss"
     with open(fname, "rb") as f:
         text = f.read().decode()
     return utils.get_scss_vars(text), utils.compile_scss_to_css(text)

--- a/timetagger/server/_assets.py
+++ b/timetagger/server/_assets.py
@@ -29,9 +29,7 @@ AUDIO_EXTS = ".wav", ".mp3", ".ogg"
 re_fas = re.compile(r"\>(\\uf[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])\<")
 
 default_template = (
-    open(resources.files("timetagger.common") / "_template.html", "rb")
-    .read()
-    .decode()
+    open(resources.files("timetagger.common") / "_template.html", "rb").read().decode()
 )
 
 


### PR DESCRIPTION
Hi @almarklein,

I took the time and tried to upgrade TimeTagger and its container images to Python 3.13.

Additionally the CI has been upgraded to also test all currently supported Python versions up to Python 3.13. Old and unmainted versions have been removed.

Minor code changes were nessecary in order to make the codebase Python 3.13 ready and get rid of deprecated function calls.

The work and testing is not fully done yet I think but before putting more work into this I wanted to get some feedback from your side if it is worth the effort.

Cheers and merry christmas 🎄,

Daniel