### PR TITLE
Updated Python version classifiers in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,6 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13"
+        "Programming Language :: Python :: 3.13",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -52,10 +52,10 @@ setup(
         "Operating System :: POSIX",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13"
     ],
 )


### PR DESCRIPTION
A little post-work for #521.

I removed the Pyhton version classifiers from `setup.py` for unmaintained Python versions and added recent ones until `3.13`.