### PR TITLE
#411 - Added latest-nonroot image tag

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -14,10 +14,8 @@ permissions:
 jobs:
 
   # Build default priviliged container image version
-  # We make it need the other jobs, so this comes last and becomes the "latest"
   docker-root:
     runs-on: ubuntu-latest
-    needs: [docker-nonroot]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -77,6 +75,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository }}
+          # no "latest" tag for non-root variant
+          flavor: latest=false
           tags: |
             type=ref,event=tag,suffix=-nonroot
             # set latest-nonroot tag for default branch

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -77,7 +77,10 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository }}
-          tags: type=ref,event=tag,suffix=-nonroot
+          tags: |
+            type=ref,event=tag,suffix=-nonroot
+            # set latest-nonroot tag for default branch
+            type=raw,value=latest-nonroot
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4

--- a/deploy/docker-compose.nonroot.yml
+++ b/deploy/docker-compose.nonroot.yml
@@ -10,7 +10,7 @@
 version: "3"
 services:
   timetagger:
-    image: ghcr.io/almarklein/timetagger:v23.9.2-nonroot
+    image: ghcr.io/almarklein/timetagger:latest-nonroot
     ports:
       - "80:80"
     volumes:


### PR DESCRIPTION
As requested in #411 I added a `latest-nonroot` tag to the nonroot image variant.

I also fixed the latest tag nonroot overwrite issue differently (disabling the push of the latest tag for the non-root variant) in order to allow the jobs to run in parallel again and to not rely on the tag overwrite to fix this.