### PR TITLE
Simplify resources.files calls and update tests

### DIFF
--- a/tests/test_server_assetserver.py
+++ b/tests/test_server_assetserver.py
@@ -1,6 +1,6 @@
 import sys
 import subprocess
-from pkg_resources import resource_filename
+from importlib import resources
 
 from timetagger.server import create_assets_from_dir
 import asgineer
@@ -11,9 +11,9 @@ from _common import run_tests
 
 # Create asset handler
 assets = {}
-assets.update(create_assets_from_dir(resource_filename("timetagger.app", ".")))
-assets.update(create_assets_from_dir(resource_filename("timetagger.common", ".")))
-assets.update(create_assets_from_dir(resource_filename("timetagger.images", ".")))
+assets.update(create_assets_from_dir(resources.files("timetagger.app")))
+assets.update(create_assets_from_dir(resources.files("timetagger.common")))
+assets.update(create_assets_from_dir(resources.files("timetagger.images")))
 asset_handler = asgineer.utils.make_asset_handler(assets, max_age=0)
 
 
@@ -74,12 +74,12 @@ def test_assets():
 
 
 hash_checker_code = """
-from pkg_resources import resource_filename
+from importlib import resources
 from timetagger.server import create_assets_from_dir, enable_service_worker
 assets = {}
-assets.update(create_assets_from_dir(resource_filename("timetagger.app", ".")))
-assets.update(create_assets_from_dir(resource_filename("timetagger.common", ".")))
-assets.update(create_assets_from_dir(resource_filename("timetagger.images", ".")))
+assets.update(create_assets_from_dir(resources.files("timetagger.app")))
+assets.update(create_assets_from_dir(resources.files("timetagger.common")))
+assets.update(create_assets_from_dir(resources.files("timetagger.images")))
 enable_service_worker(assets)
 cachename = assets["sw.js"].split("currentCacheName =")[1].split("\n")[0]
 print(cachename)

--- a/timetagger/__main__.py
+++ b/timetagger/__main__.py
@@ -55,10 +55,10 @@ if __name__ == "__main__" and len(sys.argv) >= 2:
 logger = logging.getLogger("asgineer")
 
 # Get sets of assets provided by TimeTagger
-common_assets = create_assets_from_dir(resources.files("timetagger.common") / ".")
-apponly_assets = create_assets_from_dir(resources.files("timetagger.app") / ".")
-image_assets = create_assets_from_dir(resources.files("timetagger.images") / ".")
-page_assets = create_assets_from_dir(resources.files("timetagger.pages") / ".")
+common_assets = create_assets_from_dir(resources.files("timetagger.common"))
+apponly_assets = create_assets_from_dir(resources.files("timetagger.app"))
+image_assets = create_assets_from_dir(resources.files("timetagger.images"))
+page_assets = create_assets_from_dir(resources.files("timetagger.pages"))
 
 # Combine into two groups. You could add/replace assets here.
 app_assets = dict(**common_assets, **image_assets, **apponly_assets)


### PR DESCRIPTION
After #521, pkg_resources is still used in `test_server_assetserver.py`. I've adopted the changes of the mentioned PR to this file and removed the redundant `/ "."` when creating assets.

Now, the tests should also run on Python 3.13 if setuptools is not installed.