### PR TITLE
Shorter timeout after editing record

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -1,5 +1,4 @@
-""" Invoke tasks for timetagger
-"""
+"""Invoke tasks for timetagger"""
 
 import os
 import sys

--- a/timetagger/app/stores.py
+++ b/timetagger/app/stores.py
@@ -752,7 +752,7 @@ class BaseDataStore:
         for i in range(len(items)):
             item = items[i]
             self._to_push[kind][item.key] = item
-        self.sync_soon(3)
+        self.sync_soon(1.5)
         self._set_state("pending")
 
     def sync_soon(self, timeout=10):


### PR DESCRIPTION
Helps prevent the case where a user switches tabs after making a change, causing the data not to be synced when that tab is killed. See #439