### PR TITLE
feat: add option to randomize new tag colors

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -2148,7 +2148,7 @@ class TagDialog(BaseDialog):
         self._set_color(self._default_color)
 
     def _set_random_color(self):
-        clr = "#" + Math.floor(Math.random() * 16777215).toString(16)
+        clr = utils.color_random()
         self._set_color(clr)
 
     def _set_color(self, clr):
@@ -3920,9 +3920,18 @@ class SettingsDialog(BaseDialog):
                 </select>
             </div>
             <h2><i class='fas'>\uf085</i>&nbsp;&nbsp;Misc</h2>
+            <div class='formlayout'>
+                <div>Default tag color:</div>
+                <select>
+                    <option value='default'>Default</option>
+                    <option value='name'>From Tag Name</option>
+                    <option value='random'>Random</option>
+                </select>
+            </div>
             <label>
                 <input type='checkbox' checked='true'></input>
-                Show elapsed time below start-button</label>
+                Show elapsed time below start-button
+            </label>
 
             <hr style='margin-top: 1em;' />
 
@@ -3971,6 +3980,7 @@ class SettingsDialog(BaseDialog):
             _,  # Time repr header
             self._repr_form,
             _,  # Misc header
+            self._tag_form,
             self._stopwatch_label,
             _,  # hr
             _,  # Section: per device
@@ -4031,6 +4041,12 @@ class SettingsDialog(BaseDialog):
         self._today_end_offset = self._repr_form.children[13]
         self._today_end_offset.value = today_end_offset
         self._today_end_offset.onchange = self._on_today_end_offset_change
+
+        # Tag color
+        tag_color = window.simplesettings.get("tag_color")
+        self._tag_color = self._tag_form.children[1]
+        self._tag_color.value = tag_color
+        self._tag_color.onchange = self._on_tag_color_change
 
         # Stopwatch
         show_stopwatch = window.simplesettings.get("show_stopwatch")
@@ -4127,6 +4143,10 @@ class SettingsDialog(BaseDialog):
     def _on_stopwatch_check(self):
         show_stopwatch = bool(self._stopwatch_check.checked)
         window.simplesettings.set("show_stopwatch", show_stopwatch)
+
+    def _on_tag_color_change(self):
+        tag_color = self._tag_color.value
+        window.simplesettings.set("tag_color", tag_color)
 
 
 class GuideDialog(BaseDialog):

--- a/timetagger/app/stores.py
+++ b/timetagger/app/stores.py
@@ -358,7 +358,15 @@ class SettingsStore(BaseStore):
     def get_color_for_tag(self, tag):
         info = self.get_tag_info(tag)
         color = info.get("color", "")
-        return color or window.front.COLORS.acc_clr
+        if not color:
+            if window.simplesettings.get("tag_color") == "tag_name":
+                color = utils.color_from_name(tag)
+            elif window.simplesettings.get("tag_color") == "random":
+                color = utils.color_random()
+            else:
+                color = window.front.COLORS.acc_clr
+            self.set_tag_info(tag, {"color": color})
+        return color
 
 
 class RecordStore(BaseStore):

--- a/timetagger/app/utils.py
+++ b/timetagger/app/utils.py
@@ -104,6 +104,11 @@ def color_from_name(name):
         _lasthashedcolors[name] = PALETTE1[color % len(PALETTE1)]
     return _lasthashedcolors[name]
 
+def color_random():
+    """Generate a random color"""
+    clr = "#" + Math.floor(Math.random() * 16777215).toString(16)
+    return clr
+
 
 def create_palettes():
     # The Github color palette, consisting of 8 strong colors and 8 lighter variants.
@@ -629,6 +634,7 @@ class SimpleSettings:
             "today_snap_offset": "",
             "today_end_offset": "",
             "show_stopwatch": True,
+            "tag_color": "default",
         }
         # The data store for synced source
         self._store = None


### PR DESCRIPTION
Hello! This PR is mostly a draft of an idea, so open to suggestions or contributions for how to improve this. 

I like to have colorful tags to create visual distinction on my timeline, but I don't really care to set colors myself, and manually randomizing the color each time is somewhat annoying since I commonly make new tags. This PR adds an option to the user settings for how to determine the default tag color. The options I added are:

- Default - use the current "brand yellow" color
- From Tag Name - I noticed some old code for this, so it could maybe be brought back here, but I don't think it's currently functional as is
- Random - Randomly generate a color

This seemed mostly functional when I tested it, but there's definitely some room for improvement. A couple notes:

- Random currently feels a little jarring because it will change the preview color of the tag as you type the name
- Making the color options into an enum might be a little nicer than passing around raw strings
- The from tag name setting didn't seem to work, and I didn't really try to make it work. Not sure if it's even something worth keeping around or not.
