### PR TITLE
Prevent summer/wintertime changeover from breaking week floor calculation

### DIFF
--- a/timetagger/app/dt.py
+++ b/timetagger/app/dt.py
@@ -224,10 +224,8 @@ def floor(t, res):
         tup[-1] = int((tup[-1] - 1) / resFactor) * resFactor + 1  # days are 1-based
     elif resName == "W":
         day_offset = 7 - get_first_day_of_week()
-        d.setHours(0, 0, 0, 0)
         daysoff = (d.getDay() + day_offset) % 7  # Align to a sunday/monday
-        d = Date(d.getTime() - 86_400_000 * daysoff)
-        tup = d.getFullYear(), d.getMonth(), d.getDate()
+        tup = d.getFullYear(), d.getMonth(), (d.getDate() - daysoff)
     elif resName == "M":
         tup = tup[:2]  # Note that it is zero-based (jan is zero)
         tup[-1] = int(tup[-1] / resFactor) * resFactor


### PR DESCRIPTION
During the week following the EST/EDT changeover, `dt.floor()` at the week level produces results one day earlier than it should due to the missing hour messing up the calculations. Rather than subtracting a number of seconds, we should directly decrement the day of the month instead.