### PR TITLE
Fix zero total duration for ungrouped reports

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -3025,6 +3025,7 @@ class ReportDialog(BaseDialog):
             group_list1 = [group]
             for i in range(len(records)):
                 record = records[i]
+                group.duration += record.duration
                 tagz1 = window.store.records.tags_from_record(record).join(" ")
                 if tagz1 not in name_map:
                     continue


### PR DESCRIPTION
Hey @almarklein,

I noticed that currently the report's total duration stays 00:00 if the report is completly ungrouped. Not sure if this was intended, but if not .. this should fix it.

Best