### PR TITLE
config: remove obsolete attribute 'version' from docker-compose.yml

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -7,7 +7,6 @@
 # !! In docker-compose characters '$' should be escaped as '$$'    !!
 # !! If you use a .env file, use single quotes instead of escaping !!
 
-version: "3"
 services:
   timetagger:
     image: ghcr.io/almarklein/timetagger


### PR DESCRIPTION
I installed timetagger using docker and docker warned about presence of 'version' attribute in this file. It is an obsolete attribute now, it suggested to remove it to avoid confusion.

