### PR TITLE
Improve offline usage

### DIFF
--- a/timetagger/app/stores.py
+++ b/timetagger/app/stores.py
@@ -793,6 +793,9 @@ class ConnectedDataStore(BaseDataStore):
         self._auth = window.tools.get_auth_info()
         self._auth_cantuse = None
 
+        # Load cache asynchronously without blocking
+        window.setTimeout(lambda: self._load_from_cache(), 0)
+
     def get_auth(self):
         """Get an auth info object that is guaranteed to match the username
         that the store had from the beginning. It gets automatically refreshed


### PR DESCRIPTION
A couple sync enhancements to improve the offline experience.

Summary of changes:
* Call `_save_to_cache()` in `BaseDataStore._put()` so that user changes are always cached first before pushing to server. This makes it so any records aren't lost if I close the PWA right after an edit.
* Remove the pending message if exiting before server sync--it is saved in the local cache so nothing to worry about. The alert window just interrupts the user's flow.
* Make the app feel snappier by loading data from cache immediately after page load. Previously there was a ~1 second delay between page loaded and all the existing records displaying. Since we likely have data stored in the cache, just try loading that first instead of waiting for the server.

Resolves #439