### PR TITLE
Address linter failures

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -161,7 +161,7 @@ def csvsplit(s, sep, i=0):
     # "standard", but they *do* use quotes when the value has tabs or newlines :'(
     # In our own exports, we don't allow tabs or newlines, nor quotes at the start,
     # so we should be fine with our own data.
-    global RawJS
+    global RawJS  # noqa: F824
     parts = []
     RawJS(
         """
@@ -3589,7 +3589,7 @@ class ImportDialog(BaseDialog):
             self._import_but.disabled = False
 
     async def _do_analyse(self):
-        global JSON
+        global JSON  # noqa: F824
 
         def log(s):
             self._analysis_out.innerHTML += s + "<br />"

--- a/timetagger/app/stores.py
+++ b/timetagger/app/stores.py
@@ -59,7 +59,7 @@ if this_is_js():  # pragma: no cover
         return x
 
     def to_str(x):
-        global String
+        global String  # noqa: F824
         s = String(x).slice(0, STR_MAX)
         return s.replace("\r", "").replace("\n", " ").replace("\t", " ").lstrip(' "')
 

--- a/timetagger/app/tools.py
+++ b/timetagger/app/tools.py
@@ -10,12 +10,12 @@ from pscript.stubs import window, JSON, localStorage, location, console, fetch
 
 
 def sleepms(ms):
-    global RawJS
+    global RawJS  # noqa: F824
     return RawJS("new Promise(resolve => setTimeout(resolve, ms))")
 
 
 def copy_dom_node(node):
-    global document
+    global document  # noqa: F824
 
     # Select the node (https://stackoverflow.com/questions/400212)
     sel = None


### PR DESCRIPTION
The linter has been failing because of some presumably undeclared global variables. Added inline linter ignore comments since these are not currently an issue.