### PR TITLE
Enhancement: Add version API endpoint

### DIFF
--- a/docs/docs/webapi.md
+++ b/docs/docs/webapi.md
@@ -113,6 +113,20 @@ The fields in the JSON response:
 * `records`: a list of record objects that have changed since. Can be empty.
 * `settings`: a list of settings objects that have changed since. Can be empty.
 
+### GET version
+
+To get the server version, perform the following request:
+
+```
+GET ./version
+```
+
+The fields in the JSON response:
+
+* `version`: a string indicating the TimeTagger server version.
+
+This endpoint can be used to check the server version for compatibility or debugging purposes.
+
 ### Other endpoints
 
 If you look at the [source code](https://github.com/almarklein/timetagger/blob/main/timetagger/server/_apiserver.py), you'll see a few other endpoints, e.g. to refresh the web-token and obtain the api-token. These two endpoints are only available with a web-token (not with an api-token).

--- a/tests/test_server_apiserver.py
+++ b/tests/test_server_apiserver.py
@@ -6,6 +6,7 @@ import asyncio
 from asgineer.testutils import MockTestServer
 
 from _common import run_tests
+from timetagger import __version__ as timetagger_version
 from timetagger.server._utils import decode_jwt_nocheck
 from timetagger.server import _apiserver
 from timetagger.server import (
@@ -775,6 +776,26 @@ def test_apitoken():
         headers["authtoken"] = d["token"]
         r = p.get("http://localhost/api/v2/updates?since=0", headers=headers)
         assert r.status == 200
+
+
+def test_version():
+    """Test the version API endpoint."""
+    clear_test_db()
+
+    with MockTestServer(our_api_handler) as p:
+        # Test GET version endpoint
+        r = p.get("http://localhost/api/v2/version", headers=HEADERS)
+        assert r.status == 200
+        d = dejsonize(r)
+        assert set(d.keys()) == {"version"}
+        assert isinstance(d["version"], str)
+        assert d["version"] == timetagger_version
+
+        # Test that only GET is allowed
+        r = p.put("http://localhost/api/v2/version", headers=HEADERS)
+        assert r.status == 405
+        r = p.post("http://localhost/api/v2/version", headers=HEADERS)
+        assert r.status == 405
 
 
 if __name__ == "__main__":

--- a/timetagger/server/_apiserver.py
+++ b/timetagger/server/_apiserver.py
@@ -11,6 +11,8 @@ import itemdb
 
 from ._utils import user2filename, create_jwt, decode_jwt
 
+from timetagger import __version__
+
 
 logger = logging.getLogger("asgineer")
 
@@ -88,7 +90,14 @@ class AuthException(Exception):
 async def api_handler_triage(request, path, auth_info, db):
     """The API handler that triages over the API options."""
 
-    if path == "updates":
+    if path == "version":
+        if request.method == "GET":
+            return await get_version(request, auth_info, db)
+        else:
+            expl = "/version can only be used with GET"
+            return 405, {}, "method not allowed: " + expl
+
+    elif path == "updates":
         if request.method == "GET":
             return await get_updates(request, auth_info, db)
         else:
@@ -289,6 +298,11 @@ async def get_webtoken_unsafe(username, reset=False):
 
 
 # %% The implementation
+
+
+async def get_version(request, auth_info, db):
+    result = {"version": __version__}
+    return 200, {}, result
 
 
 async def get_updates(request, auth_info, db):


### PR DESCRIPTION
## Summary

Adds a new `/api/v2/version` endpoint that returns the TimeTagger server version. This enhancement enables external applications and third-party integrations to programmatically check the server version for compatibility validation and debugging purposes.

## Motivation

Currently, there's no easy way for external applications to programmatically determine the TimeTagger server version - _(short of scraping the `window.timetaggerversion` JS variable from the web pages)_ 🙃

Allowing external applications to get the version programmatically allows for feature compatibility checking, as well as enabling informative workflows like update reminders for users.

## Changes

### API Implementation
- Added `GET /api/v2/version` endpoint in `timetagger/server/_apiserver.py`
- Endpoint returns JSON: `{"version": "25.06.1"}` (using version string from `timetagger.__version__`)
- Requires authentication via `authtoken` header, consistent with other API endpoints

### Tests
- Added test coverage in `tests/test_server_apiserver.py`
- Tests pass successfully

### Documentation
- Updated `docs/docs/webapi.md` with endpoint documentation
- Follows existing documentation format and style
- Includes usage examples and response format specification

## Backward Compatibility

This change is **fully backward compatible**. There are no changes to existing endpoints or Application behavior.

## API Usage Example

```bash
curl -H "authtoken: YOUR_TOKEN" https://timetagger.app/api/v2/version
```

Response:
```json
{
  "version": "25.06.1"
}
```