### PR TITLE
Fix linter errors in bulk edit script

### DIFF
--- a/contrib/bulk_edit/timetagger_bulk_edit.py
+++ b/contrib/bulk_edit/timetagger_bulk_edit.py
@@ -67,6 +67,7 @@ Author: Manuel Senfft (info@tagirijus.de)
 """
 
 import argparse
+import binascii
 import datetime
 from itemdb import ItemDB
 import json
@@ -286,7 +287,7 @@ class Records(BulkEditor):
                             hour=23, minute=59, second=59, microsecond=999999
                         )
                     return int(dt.timestamp())
-                except ValueError as e:
+                except ValueError:
                     return time_string
 
     def delete_records_in_range(self, from_unix_timestamp, to_unix_timestamp):


### PR DESCRIPTION
This PR addresses linting failures like [this one](https://github.com/almarklein/timetagger/actions/runs/19262026228/job/55068872199), which have been observed in recent CI jobs. 

### Observed Errors:

```
$ invoke lint
.../contrib/bulk_edit/timetagger_bulk_edit.py:163:20: F821 undefined name 'binascii'
.../contrib/bulk_edit/timetagger_bulk_edit.py:289:17: F841 local variable 'e' is assigned to but never used
Error: Process completed with exit code 1.
```

### Changes:

- Add missing import statement for undefined reference to `binascii`.
- Remove unused variable `e`.

### Result:

```
$ invoke lint
No style errors found
```

_Edit: As evidenced by the successful CI run on this PR (see below), the linter error is resolved._