### PR TITLE
Fix argument parsing with hyphens `-`

### DIFF
--- a/timetagger/_config.py
+++ b/timetagger/_config.py
@@ -77,21 +77,22 @@ def _reset_config_to_defaults():
 def _update_config_from_argv(argv):
     for i in range(len(argv)):
         arg = argv[i]
-        for name, conv, _ in Config._ITEMS:
-            if arg.startswith(f"--{name}="):
-                _, _, raw_value = arg.partition("=")
-            elif arg == f"--{name}":
-                if i + 1 < len(argv):
-                    raw_value = argv[i + 1]
+        for config_attr, conv, _ in Config._ITEMS:
+            for name in (config_attr, config_attr.replace("_", "-")):
+                if arg.startswith(f"--{name}="):
+                    _, _, raw_value = arg.partition("=")
+                elif arg == f"--{name}":
+                    if i + 1 < len(argv):
+                        raw_value = argv[i + 1]
+                    else:
+                        raise RuntimeError(f"Value for {arg} not given")
                 else:
-                    raise RuntimeError(f"Value for {arg} not given")
-            else:
-                continue
-            try:
-                setattr(config, name, conv(raw_value))
-            except Exception as err:
-                raise RuntimeError(f"Could not set config.{name}: {err}")
-            break
+                    continue
+                try:
+                    setattr(config, config_attr, conv(raw_value))
+                except Exception as err:
+                    raise RuntimeError(f"Could not set config.{config_attr}: {err}")
+                break
 
 
 def _update_config_from_env(env):


### PR DESCRIPTION
This change allows parsing configuration parameters who's names contain underscores `_` as commandline arguments with hyphens `-`.

The argv parser now parses for both the hyphenated variant, and the original (underscored) variant when matching configuration attriutes. This makes the CLI more intuitive and consistent with typical command-line tools, while also remaining backward compatible.

**Example:**
Previously, the configuration parameter `proxy_auth_headers` had to be provided via the commandline argument `--proxy_auth_headers`. It can now be provided as `--proxy-auth-headers` instead.