### PR TITLE
Order suggested tag completions most recent first, not lexicographically

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -1554,7 +1554,7 @@ class Autocompleter:
         tag_list = []
         for tag, tag_t2 in tags_dict.items():
             tag_list.push((tag, tag_t2))
-        tag_list.sort(key=lambda x: x[0])
+        tag_list.sort(key=lambda x: -x[1])
         return tag_list
 
 


### PR DESCRIPTION
Currently, if I create a new record and start typing `#foo`, timetagger will offer me a list of all tags that start with `foo` sorted lexicographically, regardless of how long ago I last used them, followed by all tags that contain `foo` sorted lexicographically. It's more useful to order the suggested completions in each group by recency.