### PR TITLE
Fix regression in time edit dialog

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -1069,10 +1069,10 @@ class StartStopEdit:
                     mm, ss = mm + self._stepwise_delta(mm, -(_stepsize)), 0
                 d1 = window.Date(year1, month1 - 1, day1, hh, mm, ss)
                 self.t1 = dt.to_time_int(d1)
-            if self.ori_t1 == self.ori_t2:
-                self.t2 = self.t1 = min(self.t1, now)
-            elif self.t1 >= self.t2:
-                self.t2 = self.t1 + 1
+                if self.ori_t1 == self.ori_t2:
+                    self.t2 = self.t1 = min(self.t1, now)
+                elif self.t1 >= self.t2:
+                    self.t2 = self.t1 + 1
 
         elif what == "time2":
             # Changing time2 -> update t2, keep t1 and t2 in check
@@ -1091,11 +1091,11 @@ class StartStopEdit:
                     mm, ss = mm + self._stepwise_delta(mm, -(_stepsize)), 0
                 d2 = window.Date(year2, month2 - 1, day2, hh, mm, ss)
                 self.t2 = dt.to_time_int(d2)
-            if self.ori_t1 == self.ori_t2:
-                self.t2 = self.t1
-            elif self.t2 <= self.t1:
-                self.t1 = self.t2
-                self.t2 = self.t1 + 1
+                if self.ori_t1 == self.ori_t2:
+                    self.t2 = self.t1
+                elif self.t2 <= self.t1:
+                    self.t1 = self.t2
+                    self.t2 = self.t1 + 1
 
         elif what == "duration":
             # Changing duration -> update t2, but keep it in check
@@ -1115,7 +1115,8 @@ class StartStopEdit:
 
         # Invoke callback and rerender
         if call_callback:
-            window.setTimeout(self.callback, 1)
+            self.callback()  # direct callback to avoid race condition #583
+            # window.setTimeout(self.callback, 1000)
 
         if action.endswith("fast"):
             self._update_duration(True)


### PR DESCRIPTION
Closes #587.

This undoes #586, and introduces a new fix for #583.
