### PR TITLE
Fix double handling of shortcut key handler

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -838,13 +838,17 @@ class StartStopEdit:
         else:
             # Switch between "already running" and "finished".
             # Since this is an existing record, we should maintain initial values.
-            if self.radio_startrlr.checked: # If the "Started earlier" radio button is checked
+            if (
+                self.radio_startrlr.checked
+            ):  # If the "Started earlier" radio button is checked
                 self.reset(self.initial_t1, self.initial_t1)
-            elif self.radio_finished.checked: # If the "Already done" radio button is checked
+            elif (
+                self.radio_finished.checked
+            ):  # If the "Already done" radio button is checked
                 range_t1, range_t2 = window.canvas.range.get_range()
                 now = dt.now()
                 if not (range_t1 <= now <= range_t2):
-                    # If the current time is not in the currently viewed range assume 
+                    # If the current time is not in the currently viewed range assume
                     #   the user is filling a historical event in the viewed range.
                     #   We will pick the hour in the center of the range as the default filled time.
                     center_time = (range_t1 + range_t2) // 2
@@ -852,10 +856,10 @@ class StartStopEdit:
                     t2 = center_time + 1800
                     self.reset(t1, t2)
                 else:
-                    # If the current time IS in the currently viewed range, 
+                    # If the current time IS in the currently viewed range,
                     #   set the start time to one hour ago and the stop time to now.
-                    self.reset(now-3600, now)
-            else: # This should never trigger since currently the only options are "start now", "started earlier", and "already done"
+                    self.reset(now - 3600, now)
+            else:  # This should never trigger since currently the only options are "start now", "started earlier", and "already done"
                 t2 = max(self.initial_t1 + 1, dt.now())
                 self.reset(self.initial_t1, t2)
 

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -1551,6 +1551,11 @@ class TopWidget(Widget):
             self._handle_button_press("guide")
         else:
             return
+
+        # Avoid double handling by canvas and window both
+        if e.currentTarget is self._canvas.node:
+            e.stopPropagation()
+
         e.preventDefault()
 
     def _handle_button_press(self, action):


### PR DESCRIPTION
The shortcut key handler fires twice in some browsers due to the bubble up from canvas to window. This causes issues when trying to move in the timeline as it jumps by multiple days instead of a single one.