### PR TITLE
Add decimal-hours toggle for duration display

### DIFF
--- a/tests/test_client_dt.py
+++ b/tests/test_client_dt.py
@@ -97,8 +97,9 @@ def test_time2str():
 
 
 def test_duration_string():
-    js = py2js(open(dt.__file__, "rb").read().decode(), docstrings=False)
-    js += "\n\nwindow = {};"
+    js = "window = {};\n" + py2js(
+        open(dt.__file__, "rb").read().decode(), docstrings=False
+    )
 
     js1 = evaljs(js, f"duration_string(5, false)")
     js2 = evaljs(js, f"duration_string(5, true)")
@@ -131,6 +132,18 @@ def test_duration_string():
     assert js4 == "0:01:05"
     assert js5 == "2:01"
     assert js6 == "2:01:05"
+
+    # Toggle decimal mode: durations render as decimal hours
+    js += "toggle_duration_decimal_mode();"
+    js1 = evaljs(js, f"duration_string(7265, false)")
+    js2 = evaljs(js, f"duration_string(7265, true)")
+    js3 = evaljs(js, f"duration_string(-7265, false)")
+    assert js1 == "2.02"
+    assert js2 == "2.02"
+    assert js3 == "-2.02"
+    js += "toggle_duration_decimal_mode();"
+    js4 = evaljs(js, f"duration_string(7265, false)")
+    assert js4 == "2h01m"
 
 
 if __name__ == "__main__":

--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -3944,6 +3944,7 @@ class SettingsDialog(BaseDialog):
             "F": "Open search dialog",
             "T": "Select time range",
             "R": "Open report dialog",
+            ".": "Toggle decimal hours",
             "I": "Open the guide",
             "Backspace": "Unselect all tags",
         }

--- a/timetagger/app/dt.py
+++ b/timetagger/app/dt.py
@@ -304,8 +304,26 @@ def duration_string_colon(t, show_secs=False):
         return f"{sign}{m // 60:.0f}:{m % 60:02.0f}"
 
 
+def toggle_duration_decimal_mode():
+    PSCRIPT_OVERLOAD = False  # noqa
+    window.duration_decimal_mode = not window.duration_decimal_mode
+    return window.duration_decimal_mode
+
+
+def duration_string_decimal(t, show_secs=False):
+    PSCRIPT_OVERLOAD = False  # noqa
+    sign = "-" if t < 0 else ""
+    t = abs(t)
+    text = f"{sign}{t / 3600:0.2f}"
+    if show_secs == 2:
+        return (text, "")
+    return text
+
+
 def duration_string(t, show_secs=False, repr=None):
     PSCRIPT_OVERLOAD = False  # noqa
+    if window.duration_decimal_mode:
+        return duration_string_decimal(t, show_secs)
     if not repr:
         repr = "hms"
         if window.simplesettings:

--- a/timetagger/app/front.py
+++ b/timetagger/app/front.py
@@ -1134,6 +1134,30 @@ class TopWidget(Widget):
             y3,
             None,
             h,
+            ["fas-\uf1ec"],
+            "duration_decimal",
+            (
+                "Show decimal hours [.]"
+                if not window.duration_decimal_mode
+                else "Show normal duration [.]"
+            ),
+            {
+                "ref": "topleft",
+                "color": (
+                    COLORS.button_text
+                    if not window.duration_decimal_mode
+                    else COLORS.acc_clr
+                ),
+            },
+        )
+        x += margin
+
+        x += self._draw_button(
+            ctx,
+            x,
+            y3,
+            None,
+            h,
             ["fas-\uf05a"],
             "guide",
             "Show guide [i]",
@@ -1547,6 +1571,8 @@ class TopWidget(Widget):
             self._handle_button_press("record_stopall")
         elif e.key.lower() == "r":
             self._handle_button_press("report")
+        elif e.key == ".":
+            self._handle_button_press("duration_decimal")
         elif e.key.lower() == "i":
             self._handle_button_press("guide")
         else:
@@ -1588,6 +1614,10 @@ class TopWidget(Widget):
 
         elif action == "guide":
             self._canvas.guide_dialog.open()
+
+        elif action == "duration_decimal":
+            dt.toggle_duration_decimal_mode()
+            self.update()
 
         elif action == "pomo":
             self._canvas.pomodoro_dialog.open()


### PR DESCRIPTION
Adds a toggle that switches duration display from the configured duration format (e.g. 27:20 or 27h20m) to decimal hours (e.g. 27.33). This was essential for me, because i have to write time on bills in decimal hours.

Changes:
- Add a header button (with a calculator icon) to toggle the mode
- Add [.] keyboard shortcut

Toggled off:
<img width="1390" height="350" alt="Bildschirmfoto 2026-07-02 um 15 17 57" src="https://github.com/user-attachments/assets/f3a196c4-a15d-49b8-a170-0a28af5315e8" />

Toggled on:
<img width="1389" height="396" alt="Bildschirmfoto 2026-07-02 um 15 18 07" src="https://github.com/user-attachments/assets/1b9ea44e-dc07-4ed5-9469-571317904d1b" />
