### PR TITLE
add dd.mm.yyyy date format option

### DIFF
--- a/timetagger/app/dialogs.py
+++ b/timetagger/app/dialogs.py
@@ -3976,6 +3976,7 @@ class SettingsDialog(BaseDialog):
                 <div>Show dates as:</div>
                 <select>
                     <option value='yyyy-mm-dd'>yyyy-mm-dd (ISO 8601)</option>
+                    <option value='dd.mm.yyyy'>dd.mm.yyyy</option>
                     <option value='dd-mm-yyyy'>dd-mm-yyyy (default)</option>
                     <option value='mm/dd/yyyy'>mm/dd/yyyy (US)</option>
                 </select>

--- a/timetagger/app/dt.py
+++ b/timetagger/app/dt.py
@@ -183,6 +183,8 @@ def format_isodate(date, fmt=None):
         return dd + "-" + mm + "-" + yyyy
     elif fmt == "mm/dd/yyyy":
         return mm + "/" + dd + "/" + yyyy
+    elif fmt == "dd.mm.yyyy":
+        return dd + "." + mm + "." + yyyy
     else:
         return date
 


### PR DESCRIPTION
Adds a new date format option dd.mm.yyyy to the settings dialog, alongside the existing ISO, EU and US formats.
This is a common format for at least German reports.